### PR TITLE
Allow configuring url patterns and optional default profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +208,7 @@ dependencies = [
  "dirs",
  "druid",
  "gio",
+ "globset",
  "gtk",
  "interprocess",
  "lazy_static",
@@ -208,6 +227,16 @@ dependencies = [
  "winreg",
  "winres",
  "xdg-mime",
+]
+
+[[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -959,6 +988,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick 0.7.20",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1726,23 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "aho-corasick 1.0.1",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rolling-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ druid = { git = "https://github.com/browsers-software/druid.git", branch = "brow
 # parse urls
 url = "2.2.2"
 
+# parse url rules
+globset = "0.4.10"
+
 # Parse .ini files (e.g Firefox profiles.ini)
 configparser = "3.0.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ pub struct OpeningRule {
     source_app: Option<String>,
     url_pattern: Option<String>,
     profile: String,
+    incognito: bool,
 }
 
 fn generate_all_browser_profiles(
@@ -316,6 +317,7 @@ fn generate_all_browser_profiles(
             source_app: r.source_app.clone(),
             url_pattern: r.url_pattern.clone(),
             profile: r.profile.clone(),
+            incognito: r.incognito.clone(),
         })
         .collect();
 
@@ -412,7 +414,7 @@ fn get_rule_for_source_app_and_url(
         if url_match && source_app_match {
             let profile_and_options = ProfileAndOptions {
                 profile: r.profile.clone(),
-                incognito: false,
+                incognito: r.incognito.clone(),
             };
             return Some(profile_and_options);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod communicate;
 
 mod chromium_profiles_parser;
 mod firefox_profiles_parser;
+mod url_rule;
 
 // a browser (with profiles), or Spotify, Zoom, etc
 pub struct GenericApp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,23 +378,15 @@ fn get_rule_for_source_app_and_url<'a>(
         return None;
     }
     let given_url = url_result.unwrap();
-    let given_url_host_maybe = given_url.host_str();
 
     for r in opening_rules {
         let mut source_app_match = false;
         let url_match = if let Some(ref url_pattern) = r.url_pattern {
-            let url_pattern_rule = url_pattern.clone();
-            let url_rule_result = Url::from_str(url_pattern_rule.as_str());
-            if url_rule_result.is_err() {
-                continue;
-            }
-            let url_rule = url_rule_result.unwrap();
+            let url_matches = url_rule::to_url_matcher(url_pattern.as_str())
+                .to_glob_matcher()
+                .url_matches(&given_url);
 
-            if let Some(given_url_host) = given_url_host_maybe {
-                url_rule.host_str().unwrap() == given_url_host
-            } else {
-                false
-            }
+            url_matches
         } else {
             true
         };

--- a/src/url_rule.rs
+++ b/src/url_rule.rs
@@ -1,0 +1,390 @@
+use std::str::FromStr;
+
+use globset::{Glob, GlobBuilder, GlobMatcher};
+use url::Url;
+
+/// [scheme://]hostname[/path][?query][#fragment]
+/// [*://]**[/**][?**][#*]
+#[derive(Debug, PartialEq)]
+pub struct UrlMatcher {
+    scheme: String,
+    hostname: String,
+    path: String,
+    query: String,
+    fragment: String,
+}
+
+pub struct UrlGlobMatcher {
+    scheme: GlobMatcher,
+    hostname: GlobMatcher,
+    path: GlobMatcher,
+    query: GlobMatcher,
+    fragment: GlobMatcher,
+}
+
+impl UrlGlobMatcher {
+    fn from_url_matcher(url_matcher: &UrlMatcher) -> Self {
+        let scheme_matcher = Self::str_to_glob(url_matcher.scheme.as_str(), "scheme");
+
+        // "my.path.**" -> "my/path/**"
+        let hostname_with_slashes = url_matcher.hostname.replace(".", "/");
+        let hostname_matcher = Self::str_to_glob(hostname_with_slashes.as_str(), "hostname");
+        let path_matcher = Self::str_to_glob(url_matcher.path.as_str(), "path");
+
+        // "name=ferret&color=purple" -> "name=ferret/color=purple"
+        let query_with_slashes = url_matcher.query.replace("&", "/");
+        let query_matcher = Self::str_to_glob(query_with_slashes.as_str(), "query");
+        let fragment_matcher = Self::str_to_glob(url_matcher.fragment.as_str(), "fragment");
+
+        Self {
+            scheme: scheme_matcher,
+            hostname: hostname_matcher,
+            path: path_matcher,
+            query: query_matcher,
+            fragment: fragment_matcher,
+        }
+    }
+
+    fn str_to_glob(pattern: &str, name: &str) -> GlobMatcher {
+        let glob = GlobBuilder::new(pattern)
+            .literal_separator(true)
+            .case_insensitive(true)
+            .build()
+            .expect(format!("illegal pattern for {name}").as_str());
+
+        let glob_matcher = glob.compile_matcher();
+        return glob_matcher;
+    }
+
+    fn to_target_url(&self, url: &Url) -> TargetUrl {
+        let scheme = url.scheme();
+        let host = url
+            .host_str()
+            .unwrap_or_else(|| panic!("no host found from url: {}", url.as_str()));
+        let path = url.path();
+        let query = url.query().unwrap_or("");
+        let fragment = url.fragment().unwrap_or("");
+
+        return TargetUrl {
+            scheme: scheme.to_string(),
+            hostname: host.to_string(),
+            path: path.to_string(),
+            query: query.to_string(),
+            fragment: fragment.to_string(),
+        };
+    }
+
+    pub fn url_str_matches(&self, url_str: &str) -> bool {
+        let url = Url::from_str(url_str).unwrap_or_else(|_| panic!("not a valid url: {}", url_str));
+
+        return self.url_matches(&url);
+    }
+
+    pub fn url_matches(&self, url: &Url) -> bool {
+        let target_url = self.to_target_url(url);
+
+        //self.scheme.is_match_candidate()
+        let scheme_matches = self.scheme.is_match(target_url.scheme);
+
+        let target_hostname_with_slashes = target_url.hostname.replace(".", "/");
+        let hostname_matches = self.hostname.is_match(target_hostname_with_slashes);
+        let path_matches = self.path.is_match(target_url.path);
+
+        let target_query_with_slashes = target_url.query.replace("&", "/");
+        let query_matches = self.query.is_match(target_query_with_slashes);
+        let fragment_matches = self.fragment.is_match(target_url.fragment);
+
+        return scheme_matches
+            && hostname_matches
+            && path_matches
+            && query_matches
+            && fragment_matches;
+    }
+}
+
+impl UrlMatcher {
+    pub fn to_glob_matcher(&self) -> UrlGlobMatcher {
+        UrlGlobMatcher::from_url_matcher(self)
+    }
+}
+
+struct TargetUrl {
+    scheme: String,
+    hostname: String,
+    path: String,
+    query: String,
+    fragment: String,
+}
+
+// TODO: parse from the end to beginning
+fn extract_part_matchers(full_rule: &str) -> UrlMatcher {
+    // full_rule = https://hostname/path?query#fragment
+    //assert_eq!(s.find("pard"), Some(17));
+    let scheme_end_index = full_rule.find("://").expect("no scheme with :// suffix");
+    // https
+    let scheme_pattern = &full_rule[..scheme_end_index];
+    // hostname/path?query#fragment
+    let after_scheme = &full_rule[scheme_end_index + 3..];
+
+    let after_hostname_index = after_scheme.find("/").expect("no hostname with / suffix");
+    // hostname
+    let hostname_pattern = &after_scheme[..after_hostname_index];
+    // /path?query#fragment
+    let after_hostname = &after_scheme[after_hostname_index..];
+
+    let after_path_index = after_hostname.find("?").expect("no path with ? suffix");
+    // /path
+    let path_pattern = &after_hostname[..after_path_index];
+    // query#fragment
+    let after_path = &after_hostname[after_path_index + 1..];
+
+    let after_query_index = after_path.find("#").expect("no query with # suffix");
+    // query
+    let query_pattern = &after_path[..after_query_index];
+    // fragment
+    let after_query = &after_path[after_query_index + 1..];
+    // fragment
+    let fragment_pattern = &after_query;
+
+    return UrlMatcher {
+        scheme: scheme_pattern.to_string(),
+        hostname: hostname_pattern.to_string(),
+        path: path_pattern.to_string(),
+        query: query_pattern.to_string(),
+        fragment: fragment_pattern.to_string(),
+    };
+}
+
+pub fn to_url_matcher(rule: &str) -> UrlMatcher {
+    let full_rule = transform_to_full_match(rule);
+    let url_matcher = extract_part_matchers(&full_rule);
+    println!("{:?}", url_matcher);
+    return url_matcher;
+}
+
+fn transform_to_full_match(rule: &str) -> String {
+    let rule = add_scheme_matcher(rule);
+    // hostname matcher is mandatory
+    let rule = add_path_matcher(rule.as_str());
+    let rule = add_query_matcher(rule.as_str());
+    let rule = add_fragment_matcher(rule.as_str());
+    return rule;
+}
+
+fn add_scheme_matcher(rule: &str) -> String {
+    return if !rule.contains("://") {
+        String::from("*://") + rule
+    } else {
+        rule.to_string()
+    };
+}
+
+// requires scheme matcher to be already present
+fn add_path_matcher(rule: &str) -> String {
+    let scheme_end_index = rule.find("://").expect("no scheme with :// suffix");
+    // hostname/path?query#fragment
+    let after_scheme = &rule[scheme_end_index + 3..];
+
+    return if !after_scheme.contains("/") {
+        rule.to_string() + "/**" // path can have multiple parts
+    } else {
+        rule.to_string()
+    };
+}
+
+fn add_query_matcher(rule: &str) -> String {
+    return if !rule.contains("?") {
+        rule.to_string() + "?**" // query can have multiple parameters
+    } else {
+        rule.to_string()
+    };
+}
+
+fn add_fragment_matcher(rule: &str) -> String {
+    return if !rule.contains("#") {
+        rule.to_string() + "#*" // fragment has only one part
+    } else {
+        rule.to_string()
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transform_hostname_to_full_match() {
+        assert_eq!(transform_to_full_match("example.com"), "*://example.com/**?**#*");
+    }
+
+    #[test]
+    fn test_extract_part_matchers() {
+        assert_eq!(
+            extract_part_matchers("*://example.com/?#"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/".to_string(),
+                query: "".to_string(),
+                fragment: "".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_url_matcher_parses_full_match() {
+        assert_eq!(
+            to_url_matcher("*://example.com/?#"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/".to_string(),
+                query: "".to_string(),
+                fragment: "".to_string(),
+            }
+        );
+    }
+    #[test]
+    fn test_to_url_matcher_fills_scheme_with_wildcard() {
+        assert_eq!(
+            to_url_matcher("example.com/?#"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/".to_string(),
+                query: "".to_string(),
+                fragment: "".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_url_matcher_fills_scheme_fragment_with_wildcard() {
+        assert_eq!(
+            to_url_matcher("example.com/?"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/".to_string(),
+                query: "".to_string(),
+                fragment: "*".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_url_matcher_fills_scheme_query_fragment_with_wildcard() {
+        assert_eq!(
+            to_url_matcher("example.com/"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/".to_string(),
+                query: "**".to_string(),
+                fragment: "*".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_url_matcher_fills_scheme_path_query_fragment_with_wildcard() {
+        assert_eq!(
+            to_url_matcher("example.com"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/**".to_string(),
+                query: "**".to_string(),
+                fragment: "*".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_url_matcher_fills_path_and_query_and_fragment_with_wildcard() {
+        assert_eq!(
+            to_url_matcher("*://example.com"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "example.com".to_string(),
+                path: "/**".to_string(),
+                query: "**".to_string(),
+                fragment: "*".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_url_matcher_examples() {
+        assert_eq!(
+            to_url_matcher("app.company.xyz/v2/**"),
+            UrlMatcher {
+                scheme: "*".to_string(),
+                hostname: "app.company.xyz".to_string(),
+                path: "/v2/**".to_string(),
+                query: "**".to_string(),
+                fragment: "*".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_url_matches_example_1() {
+        let url_matcher = to_url_matcher("app.company.xyz/v2/**");
+        let url_glob_matcher = url_matcher.to_glob_matcher();
+        let matches =
+            url_glob_matcher.url_str_matches("https://app.company.xyz/v2/matches/everything");
+        assert_eq!(matches, true);
+    }
+
+    #[test]
+    fn test_url_matches_matches_path_with_two_asterisk() {
+        let url_matcher = to_url_matcher("beginning.**/**");
+        let url_glob_matcher = url_matcher.to_glob_matcher();
+        let matches = url_glob_matcher
+            .url_str_matches("https://beginning.of.something.great/v2/matches/everything");
+        assert_eq!(matches, true);
+    }
+
+    #[test]
+    fn test_url_matches_doesnt_match_path_with_one_asterisk() {
+        let url_matcher = to_url_matcher("beginning.**/*");
+        let url_glob_matcher = url_matcher.to_glob_matcher();
+        let matches = url_glob_matcher
+            .url_str_matches("https://beginning.of.something.great/v2/matches/everything");
+        assert_eq!(matches, false);
+    }
+
+    #[test]
+    fn test_url_matches_doesnt_matches_domain_with_two_asterisks() {
+        assert_eq!(
+            to_url_matcher("beginning.**")
+                .to_glob_matcher()
+                .url_str_matches("https://beginning.of.something.great"),
+            true
+        );
+
+        assert_eq!(
+            to_url_matcher("beginning.**.great")
+                .to_glob_matcher()
+                .url_str_matches("https://beginning.of.something.great"),
+            true
+        );
+
+        assert_eq!(
+            to_url_matcher("beginning.**.notgreat")
+                .to_glob_matcher()
+                .url_str_matches("https://beginning.of.something.great"),
+            false
+        );
+    }
+
+    #[test]
+    fn test_url_matches_doesnt_match_domain_with_one_asterisk() {
+        let url_matcher = to_url_matcher("beginning.*/**");
+        let url_glob_matcher = url_matcher.to_glob_matcher();
+        let matches = url_glob_matcher
+            .url_str_matches("https://beginning.of.something.great/v2/matches/everything");
+        assert_eq!(matches, false);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,15 @@ pub struct Config {
     hidden_apps: Vec<String>,
     hidden_profiles: Vec<String>,
     profile_order: Vec<String>,
+    default_profile: Option<ProfileAndOptions>,
     rules: Vec<ConfigRule>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(default)]
+pub struct ProfileAndOptions {
+    pub profile: String,
+    pub incognito: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -95,6 +103,10 @@ impl Config {
 
     pub fn get_rules(&self) -> &Vec<ConfigRule> {
         return &self.rules;
+    }
+
+    pub fn get_default_profile(&self) -> &Option<ProfileAndOptions> {
+        return &self.default_profile;
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,7 +29,7 @@ pub fn set_as_default_web_browser() -> bool {
     return true;
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(default)]
 pub struct Config {
     hidden_apps: Vec<String>,
@@ -46,11 +46,13 @@ pub struct ProfileAndOptions {
     pub incognito: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(default)]
 pub struct ConfigRule {
     pub source_app: Option<String>,
     pub url_pattern: Option<String>,
     pub profile: String,
+    pub incognito: bool,
 }
 
 impl Config {


### PR DESCRIPTION
Implements parts of #18

Format for rules stays the same:
```
rules: [
{
    "url_pattern": "https://something.domain.com"
    "profile": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome#Profile 1",
    "incognito": false, // defaults to false
}
]
```

Matching:

- `"something"` matches exact domain, with any scheme and path: `*://something/**`
- `"https://something"` matches exact domain, with https scheme and any path: `http://something/**`
- `"https://something/**/end"` matches exact domain, with https scheme and any path ending with /end: `http://something/**end`

Wildcards:
 - domain, path and query accepts `*` for single component and `**` for all components
   - domain components are `a.b.c`
   - path components are `a/b/c`
   - query components are `a&b&c`
- scheme and fragment accept `*`