### PR TITLE
Windows: support non-browser apps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ gtk = { version = "0.16.2" }
 winreg = "0.50.0"
 
 # same version as druid-shell uses
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["ntdef"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 # To embed .ico into .exe

--- a/src/browser_repository.rs
+++ b/src/browser_repository.rs
@@ -382,8 +382,7 @@ impl SupportedAppRepository {
     }
 
     fn spotify_app() -> SupportedApp {
-        let app_id =
-            AppIdentifier::new("com.spotify.client", "spotify_spotify.desktop", "TODOWINDOWS");
+        let app_id = AppIdentifier::new("com.spotify.client", "spotify_spotify.desktop", "spotify");
 
         Self::generic_app_with_url(
             app_id,
@@ -406,7 +405,7 @@ impl SupportedAppRepository {
         let app_id = AppIdentifier {
             mac_bundle_id: "com.workflowy.desktop".to_string(),
             linux_desktop_id: "LINUXTODO".to_string(),
-            windows_app_id: "WINDOWSTODO".to_string(),
+            windows_app_id: "URL:workflowy".to_string(),
         };
 
         Self::generic_app_with_url(app_id, vec!["workflowy.com".to_string()], convert_workflowy_uri)

--- a/src/chromium_profiles_parser.rs
+++ b/src/chromium_profiles_parser.rs
@@ -4,12 +4,10 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use druid::piet::TextStorage;
 use serde_json::{Map, Value};
 use tracing::{debug, info};
-use url::Url;
 
-use crate::{paths, utils, InstalledBrowserProfile};
+use crate::{InstalledBrowserProfile, paths, utils};
 
 pub fn find_chromium_profiles(
     chromium_user_dir: &Path,

--- a/src/linux_utils.rs
+++ b/src/linux_utils.rs
@@ -114,7 +114,7 @@ impl OsHelper {
         let executable_path_best_guess = command_parts
             .iter()
             .rfind(|component| !component.starts_with("%") && !component.starts_with("-"))
-            .map(|path_perhaps| Path::new(path_perhaps.as_str()))
+            .map(|path_perhaps| Path::new(path_perhaps))
             .unwrap_or(Path::new("unknown"));
 
         // TODO: get correct path for firefox snap, which one is actually used to calculate installation id in profiles.ini

--- a/src/url_rule.rs
+++ b/src/url_rule.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use globset::{Glob, GlobBuilder, GlobMatcher};
+use globset::{GlobBuilder, GlobMatcher};
 use url::Url;
 
 /// [scheme://]hostname[/path][?query][#fragment]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,23 +1,22 @@
+use std::{fs, u32};
 use std::fs::File;
-use std::io::{BufReader, ErrorKind};
-use std::path::{Path, PathBuf};
-use std::{fs, io, u32};
+use std::io::BufReader;
+use std::path::Path;
 
 use druid::image;
-use druid::image::imageops::FilterType;
 use druid::image::{ImageFormat, Rgba};
+use druid::image::imageops::FilterType;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
-use url::Url;
 
+use crate::{InstalledBrowser, paths, SupportedAppRepository};
 #[cfg(target_os = "linux")]
 use crate::linux_utils;
 #[cfg(target_os = "macos")]
 use crate::macos_utils;
 #[cfg(target_os = "windows")]
 use crate::windows_utils;
-use crate::{paths, InstalledBrowser, SupportedAppRepository};
 
 #[cfg(target_os = "macos")]
 pub fn set_as_default_web_browser() -> bool {

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -63,14 +63,22 @@ impl OsHelper {
 
         hklm_apps.append(&mut hkcu_apps);
 
+        if scheme != "https" {
+            let classes = RegKey::predef(HKEY_CLASSES_ROOT);
+            //let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+            //let classes = hklm.open_subkey("SOFTWARE\\Classes").unwrap();
+
+            //let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+            //let classes = hkcu.open_subkey("SOFTWARE\\Classes").unwrap();
+
+            let mut class_apps = Self::find_applications_for_class(scheme, classes);
+            hklm_apps.append(&mut class_apps);
+        }
+
         hklm_apps
     }
 
-    fn find_applications_for_class(scheme: &str, root: RegKey) -> Vec<AppInfoHolder> {
-        let classes = RegKey::predef(HKEY_CLASSES_ROOT);
-
-        //let classes = root.open_subkey("SOFTWARE\\Classes").unwrap();
-
+    fn find_applications_for_class(scheme: &str, classes: RegKey) -> Vec<AppInfoHolder> {
         let classes_keys = classes.enum_keys();
         let apps = classes_keys
             .map(|result| result.unwrap())
@@ -110,10 +118,6 @@ impl OsHelper {
         scheme: &str,
         root: RegKey,
     ) -> Vec<AppInfoHolder> {
-        if scheme != "https" {
-            return Self::find_applications_for_class(scheme, root);
-        }
-
         let start_menu_internet = root
             .open_subkey("SOFTWARE\\Clients\\StartMenuInternet")
             .unwrap();


### PR DESCRIPTION
Adds initial support for custom apps as linux/mac already had.
Doesn't yet try hard to find icon and application name if it's not under registered handler in registry.