### PR TITLE
Initial Slack support

### DIFF
--- a/src/chromium_profiles_parser.rs
+++ b/src/chromium_profiles_parser.rs
@@ -68,6 +68,7 @@ pub fn find_chromium_profiles(
             profile_cli_container_name: None,
             profile_name: profile_name,
             profile_icon: profile_icon_path,
+            profile_restricted_url_patterns: vec![],
         })
     }
 

--- a/src/firefox_profiles_parser.rs
+++ b/src/firefox_profiles_parser.rs
@@ -174,6 +174,7 @@ pub fn find_firefox_profiles(
             profile_cli_container_name: None,
             profile_name: profile_name.to_string(),
             profile_icon: None,
+            profile_restricted_url_patterns: vec![],
         });
 
         if !container_names.is_empty() {
@@ -183,6 +184,7 @@ pub fn find_firefox_profiles(
                     profile_cli_container_name: Some(container_name.to_string()),
                     profile_name: profile_name.to_string() + " " + container_name.as_str(),
                     profile_icon: None,
+                    profile_restricted_url_patterns: vec![],
                 })
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-use std::{env, thread};
 use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::process::Command;
 use std::str::FromStr;
-use std::sync::{Arc, mpsc};
 use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{mpsc, Arc};
+use std::{env, thread};
 
 use druid::{ExtEventSink, Target, UrlOpenInfo};
 use serde::{Deserialize, Serialize};
@@ -41,6 +41,7 @@ pub mod communicate;
 
 mod chromium_profiles_parser;
 mod firefox_profiles_parser;
+mod slack_profiles_parser;
 mod url_rule;
 
 // a browser (with profiles), or Spotify, Zoom, etc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,15 +114,15 @@ impl BrowserCommon {
 
     fn create_command(
         &self,
-        profile_cli_arg_value: &str,
-        profile_cli_container_name: Option<&String>,
+        common_browser_profile: &CommonBrowserProfile,
         url: &str,
         incognito_mode: bool,
     ) -> Command {
+        let profile_cli_arg_value: &str = &common_browser_profile.profile_cli_arg_value;
         let profile_args = self.supported_app.get_profile_args(profile_cli_arg_value);
         let app_url = self
             .supported_app
-            .get_transformed_url(profile_cli_container_name, url);
+            .get_transformed_url(common_browser_profile, url);
 
         let (main_command, arguments) = self.command.split_at(1);
         let main_command = main_command.first().unwrap(); // guaranteed to not be empty
@@ -277,12 +277,7 @@ impl CommonBrowserProfile {
     }
 
     fn create_command(&self, url: &str, incognito_mode: bool) -> Command {
-        return self.app.create_command(
-            &self.profile_cli_arg_value,
-            self.profile_cli_container_name.as_ref(),
-            url,
-            incognito_mode,
-        );
+        return self.app.create_command(self, url, incognito_mode);
     }
 }
 

--- a/src/linux_utils.rs
+++ b/src/linux_utils.rs
@@ -157,7 +157,8 @@ impl OsHelper {
         let _string = app_info.to_string();
         //println!("app_info: {}", id);
 
-        let profiles = supported_app.find_profiles(executable_path_best_guess.clone(), is_snap);
+        let profiles =
+            supported_app.find_profiles(executable_path_best_guess.clone(), is_snap, false);
 
         let browser = InstalledBrowser {
             command: command_parts.clone(),
@@ -165,7 +166,7 @@ impl OsHelper {
             display_name: display_name.to_string(),
             bundle: supported_app.get_app_id().to_string(),
             user_dir: supported_app
-                .get_app_config_dir_absolute(is_snap)
+                .get_app_config_dir_absolute(is_snap, false)
                 .to_string(),
             icon_path: icon_path_str.clone(),
             profiles: profiles,

--- a/src/macos_utils.rs
+++ b/src/macos_utils.rs
@@ -235,22 +235,22 @@ impl OsHelper {
         fs::create_dir_all(icons_root_dir.as_path()).unwrap();
 
         // to for each bundle id copy the domain
-        let bundle_ids_and_domains: Vec<(String, Vec<String>)> = schemes
+        let bundle_ids_and_domain_patterns: Vec<(String, Vec<String>)> = schemes
             .iter()
-            .map(|(scheme, domains)| (find_bundle_ids_for_url_scheme(scheme), domains))
-            .flat_map(|(bundle_ids, domains)| {
+            .map(|(scheme, domain_patterns)| (find_bundle_ids_for_url_scheme(scheme), domain_patterns))
+            .flat_map(|(bundle_ids, domain_patterns)| {
                 let bundle_id_and_domains: Vec<(String, Vec<String>)> = bundle_ids
                     .iter()
-                    .map(|bundle_id| (bundle_id.clone(), domains.clone()))
+                    .map(|bundle_id| (bundle_id.clone(), domain_patterns.clone()))
                     .collect();
 
                 bundle_id_and_domains
             })
             .collect();
 
-        for (bundle_id, domains) in bundle_ids_and_domains {
+        for (bundle_id, domain_patterns) in bundle_ids_and_domain_patterns {
             let browser_maybe =
-                self.to_installed_browser(bundle_id.as_str(), icons_root_dir.as_path(), domains);
+                self.to_installed_browser(bundle_id.as_str(), icons_root_dir.as_path(), domain_patterns);
             if let Some(browser) = browser_maybe {
                 info!("Added app: {:?}", browser);
                 browsers.push(browser);
@@ -264,7 +264,7 @@ impl OsHelper {
         &self,
         bundle_id: &str,
         icons_root_dir: &Path,
-        restricted_domains: Vec<String>,
+        restricted_domain_patterns: Vec<String>,
     ) -> Option<InstalledBrowser> {
         if bundle_id == "software.Browsers" {
             // this is us, skip
@@ -273,7 +273,7 @@ impl OsHelper {
 
         let supported_app = self
             .app_repository
-            .get_or_generate(bundle_id, &restricted_domains);
+            .get_or_generate(bundle_id, &restricted_domain_patterns);
         let icon_filename = bundle_id.to_string() + ".png";
         let full_stored_icon_path = icons_root_dir.join(icon_filename);
 
@@ -300,7 +300,7 @@ impl OsHelper {
             user_dir: supported_app.get_app_config_dir_absolute(false).to_string(),
             icon_path: icon_path_str.clone(),
             profiles: supported_app.find_profiles(executable_path.as_path(), false),
-            restricted_domains: restricted_domains,
+            restricted_domains: restricted_domain_patterns,
         };
 
         return Some(browser);

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -86,6 +86,38 @@ pub fn get_firefox_user_dir_root() -> PathBuf {
     return windows_utils::get_unsandboxed_roaming_config_dir();
 }
 
+// ~/Library/Application Support/
+#[cfg(target_os = "macos")]
+pub fn get_user_home_for_unsandboxed_app() -> PathBuf {
+    return macos_utils::macos_get_unsandboxed_home_dir();
+}
+
+// ~/
+#[cfg(target_os = "macos")]
+pub fn get_user_home_for_sandboxed_app(app_id: &str) -> PathBuf {
+    return macos_utils::macos_get_sandboxed_home_dir(app_id);
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_user_home_for_unsandboxed_app() -> PathBuf {
+    return PathBuf::new();
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_user_home_for_sandboxed_app(app_id: &str) -> PathBuf {
+    return PathBuf::new();
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_user_home_for_unsandboxed_app() -> PathBuf {
+    return PathBuf::new();
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_user_home_for_sandboxed_app(app_id: &str) -> PathBuf {
+    return PathBuf::new();
+}
+
 #[cfg(target_os = "macos")]
 pub fn get_snap_root() -> PathBuf {
     return PathBuf::new();

--- a/src/slack_profiles_parser.rs
+++ b/src/slack_profiles_parser.rs
@@ -55,11 +55,25 @@ pub fn find_slack_profiles(
         };*/
         let profile_icon_path = None;
 
+        let workspace_url_pattern = format!("{}.slack.com", workspace.domain.as_str());
+        let enterprise_workspace_url_pattern =
+            format!("{}.enterprise.slack.com", workspace.domain.as_str());
+        let slack_gov_workspace_url_pattern =
+            format!("{}.slack-gov.com", workspace.domain.as_str());
+
+        let app_url_pattern = format!("app.slack.com/**/{}/**", workspace.id.as_str());
+
         browser_profiles.push(InstalledBrowserProfile {
             profile_cli_arg_value: workspace.id.to_string(),
             profile_cli_container_name: Some(workspace.domain.to_string()),
             profile_name: workspace.name,
             profile_icon: profile_icon_path,
+            profile_restricted_url_patterns: vec![
+                workspace_url_pattern,
+                //enterprise_workspace_url_pattern,
+                //slack_gov_workspace_url_pattern,
+                //app_url_pattern,
+            ],
         })
     }
     return browser_profiles;

--- a/src/slack_profiles_parser.rs
+++ b/src/slack_profiles_parser.rs
@@ -1,0 +1,152 @@
+use std::fs;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+use serde_json::{Map, Value};
+use tracing::{debug, info};
+
+use crate::{paths, utils, InstalledBrowserProfile};
+
+pub fn find_slack_profiles(
+    slack_user_dir: &Path,
+    _binary_path: &Path,
+    app_id: &str,
+) -> Vec<InstalledBrowserProfile> {
+    let mut browser_profiles: Vec<InstalledBrowserProfile> = Vec::new();
+
+    let root_state_file = slack_user_dir.join("storage/root-state.json");
+    debug!("Slack Root State Path: {:?}", root_state_file);
+    // Depending if installed from app store or not, path is:
+    // ~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack/storage/root-state.json
+    // ~/Library/Application Support/Slack/storage/root-state.json
+
+    if !root_state_file.exists() {
+        info!("Could not find {}", root_state_file.display());
+        return browser_profiles;
+    }
+
+    let workspace_map = SlackWorkspacesMap::new_from_root_state(root_state_file.as_path());
+    let workspaces = workspace_map.parse_profiles();
+    for workspace in workspaces {
+        let cache_root_dir = paths::get_cache_root_dir();
+        let profiles_icons_root_dir = cache_root_dir.join("icons").join("profiles");
+        fs::create_dir_all(profiles_icons_root_dir.as_path()).unwrap();
+        let profiles_icons_root = profiles_icons_root_dir.join(app_id);
+        fs::create_dir_all(profiles_icons_root.as_path()).unwrap();
+
+        /*let image_file_path = workspace.icon_88;
+        let profile_icon_path = if image_file_path != "" {
+            let png_file = File::open(image_file_path.as_path()).unwrap();
+            let mut png_file_reader = BufReader::new(png_file);
+            let mut buffer = Vec::new();
+            // Read file into vector
+            let result = png_file_reader.read_to_end(&mut buffer);
+            if result.is_err() {
+                None
+            } else {
+                let to_filename = workspace.domain.to_string() + ".png";
+                let png_file_path = profiles_icons_root.join(to_filename);
+                utils::save_as_circular(buffer, png_file_path.as_path());
+                Some(png_file_path.to_str().unwrap().to_string())
+            }
+        } else {
+            None
+        };*/
+        let profile_icon_path = None;
+
+        browser_profiles.push(InstalledBrowserProfile {
+            profile_cli_arg_value: workspace.id.to_string(),
+            profile_cli_container_name: Some(workspace.domain.to_string()),
+            profile_name: workspace.name,
+            profile_icon: profile_icon_path,
+        })
+    }
+    return browser_profiles;
+}
+
+pub struct SlackWorkspacesMap {
+    workspaces_map: Map<String, Value>,
+}
+
+impl SlackWorkspacesMap {
+    pub fn new_from_root_state(local_state_file_path: &Path) -> Self {
+        Self {
+            workspaces_map: Self::workspaces_map(local_state_file_path),
+        }
+    }
+
+    fn workspaces_map(local_state_file_path: &Path) -> Map<String, Value> {
+        // Open the file in read-only mode with buffer.
+        let file = File::open(local_state_file_path).unwrap();
+        let reader = BufReader::new(file);
+        let v: Value = serde_json::from_reader(reader).unwrap();
+        let workspaces = &v["workspaces"];
+        let workspaces_map = workspaces.as_object().unwrap();
+        return workspaces_map.to_owned();
+    }
+
+    pub fn parse_profiles(self) -> Vec<SlackWorkspace> {
+        //let chrome_attributes_finder = ChromeAttributesFinder::new();
+        let workspaces_map = self.workspaces_map;
+        let profiles_count = workspaces_map.len();
+
+        let mut profiles_vec: Vec<SlackWorkspace> = Vec::with_capacity(profiles_count);
+
+        for (domain_name, workspace) in workspaces_map {
+            let domain = workspace["domain"].as_str().unwrap_or("").to_string();
+
+            let id = workspace["id"].as_str().unwrap_or("").to_string();
+
+            let name = workspace["name"].as_str().unwrap_or("").to_string();
+
+            let icon = workspace["icon"].as_object().unwrap();
+            let image_68 = icon["image_68"].as_str().unwrap_or("").to_string();
+            let image_88 = icon["image_88"].as_str().unwrap_or("").to_string();
+
+            profiles_vec.push(SlackWorkspace {
+                domain: domain,
+                id: id,
+                name: name,
+                icon_68: image_68,
+                icon_88: image_88,
+            });
+        }
+        // constant ordering (well based on name)
+        profiles_vec.sort_by(|p1, p2| p1.name.cmp(&p2.name));
+        return profiles_vec;
+    }
+}
+
+pub struct SlackWorkspace {
+    pub domain: String,
+    pub id: String,
+    pub name: String,
+    pub icon_68: String,
+    pub icon_88: String,
+}
+
+/*
+ "workspaces": {
+   "T09NY5SBT": {
+     "domain": "kubernetes",
+     "id": "T09NY5SBT",
+     "icon": {
+       "image_68": "https://avatars.slack-edge.com/2018-04-11/346300247111_7257b45e7a19f5230da9_68.png",
+       "image_88": "https://avatars.slack-edge.com/2018-04-11/346300247111_7257b45e7a19f5230da9_88.png"
+     },
+     "name": "Kubernetes",
+     "order": 0
+   },
+   "T05ALPT0XU6": {
+     "domain": "browsersgroup",
+     "id": "T05ALPT0XU6",
+     "icon": {
+       "image_68": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0017-68.png",
+       "image_88": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0017-88.png"
+     },
+     "name": "Browsers",
+     "order": 1
+   }
+ },
+*/

--- a/src/slack_url_parser.rs
+++ b/src/slack_url_parser.rs
@@ -1,0 +1,115 @@
+use tracing::info;
+use url::Url;
+
+pub fn convert_slack_uri(profile_team_id: &str, profile_team_domain: &str, url: &Url) -> String {
+    let unknown = format!("slack://channel?team={}", profile_team_id);
+
+    let url_host_str = (&url.host_str().unwrap()).to_string();
+
+    let path_segments_maybe = url.path_segments();
+    let url_path_segments_maybe = path_segments_maybe.map(|c| {
+        let vec = c.map(str::to_string).collect::<Vec<_>>();
+        vec
+    });
+
+    // https://slack.com/help/articles/221769328-Locate-your-Slack-URL
+    // https://api.slack.com/reference/deep-linking#supported_URIs
+    return if url_host_str == format!("{}.slack.com", profile_team_domain) {
+        info!("Domain matches Slack profile");
+
+        // Slack commands:
+        //   channel
+        //   file
+        //   team
+
+        // Slack query params:
+        //      id: ([CDG][A-Z0-9]{8,})
+        //    team: (T[A-Z0-9]{8,})
+        // message: ([0-9]+\.[0-9]+)
+
+        // Team host:
+        //    File:            https://<team-domain-name>.slack.com/messages/<ignored_id>/files/<file_id>
+        //    Channel:         https://<team-domain-name>.slack.com/archives/<channel_id>
+        //    Channel message: https://<team-domain-name>.slack.com/archives/<channel_id>/p<timestamp_without_decimal>
+        //    User:            https://<team-domain-name>.slack.com/team/<user_id>
+        //    User?:           https://<team-domain-name>.slack.com/messages/<ignored_id>/team/<user_id>
+
+        if url_path_segments_maybe.is_some() {
+            let segments = url_path_segments_maybe.unwrap();
+            let resource_type_maybe = segments.get(0);
+            let resource_id_maybe = segments.get(1);
+
+            let uri_maybe =
+                resource_type_maybe
+                    .zip(resource_id_maybe)
+                    .map(|(resource_type, resource_id)| {
+                        let subresource_id_maybe = segments.get(2);
+
+                        match (resource_type.as_str(), subresource_id_maybe) {
+                            ("team", _) => {
+                                // User; resource_id: user id
+                                // From: https://<team-domain>.slack.com/team/<resource_id>
+                                //   To: slack://team?team=<team-id>&id=<resource_id>
+                                format!("slack://team?team={}&id={}", profile_team_id, resource_id)
+                            }
+                            ("files", Some(file_id)) => {
+                                // File; resource_id: user id; subresource_id: file id
+                                // From https://<team-domain>.slack.com/files/<resource_id>/<file-id>/<filename>
+                                //   To slack://file?team=<team-id>&id=<file-id>
+                                format!("slack://file?team={}&id={}", resource_id, file_id)
+                            }
+                            ("archives", Some(message_id)) => {
+                                let query_pairs = url.query_pairs();
+                                let thread_ts_maybe: Option<String> = query_pairs
+                                    .into_iter()
+                                    .find(|(key, value)| key == "thread_ts")
+                                    .map(|(key, value)| value.to_string());
+
+                                match thread_ts_maybe {
+                                    // Channel thread message; resource_id: channel id; subresource_id: message id
+                                    // From https://<team-domain>.slack.com/archives/C05BH52KSC8/p1686336166083089?thread_ts=1686336161.925399&cid=C05BH52KSC8
+                                    //   To slack://channel?team=<team-id>&id=<resource_id>&message=1686336166.083089&thread_ts=1686232159.321829
+                                    Some(thread_ts) => format!(
+                                        "slack://channel?team={}&id={}&message={}&thread_ts={}",
+                                        profile_team_id, resource_id, message_id, thread_ts
+                                    ),
+                                    // Channel Message; resource_id: channel id; subresource_id: message id
+                                    // From https://<team-domain>.slack.com/archives/<resource_id>/p1647522989096739
+                                    //   To slack://channel?team=<team-id>&id=<resource_id>&message=1647522989.096739
+                                    None => format!(
+                                        "slack://channel?team={}&id={}&message={}",
+                                        profile_team_id, resource_id, message_id
+                                    ),
+                                }
+                            }
+                            ("archives", None) => {
+                                // Channel; resource_id: channel id
+                                // From https://<team-domain>.slack.com/archives/<channel_id>
+                                //   To slack://channel?team=<team-id>&id=<channel_id>
+                                format!(
+                                    "slack://channel?team={}&id={}",
+                                    profile_team_id, resource_id
+                                )
+                            }
+                            _ => unknown.clone(),
+                        }
+                    });
+
+            let slack_protocol_url = uri_maybe.unwrap_or(unknown.clone());
+            return slack_protocol_url;
+        }
+
+        format!("slack://channel?team={}", profile_team_id)
+    } else if url_host_str == format!("{}.slack-gov.com", profile_team_domain) {
+        // https://mycompany.slack-gov.com/...
+        format!("slack://channel?team={}", profile_team_id)
+    } else if url_host_str == format!("{}.enterprise.slack.com", profile_team_domain) {
+        // https://mycompany.enterprise.slack.com/...
+        format!("slack://channel?team={}", profile_team_id)
+    } else if url_host_str == "app.slack.com" {
+        // https://app.slack.com/client/...
+        format!("slack://channel?team={}", profile_team_id)
+    } else {
+        format!("slack://channel?team={}", profile_team_id)
+    };
+}

--- a/src/url_rule.rs
+++ b/src/url_rule.rs
@@ -102,7 +102,7 @@ impl UrlGlobMatcher {
             && fragment_matches;
     }
 
-    pub fn hostname_matches(&self, target_hostname: &str) -> bool {
+    fn hostname_matches(&self, target_hostname: &str) -> bool {
         let target_hostname_with_slashes = target_hostname.replace(".", "/");
         return self.hostname.is_match(target_hostname_with_slashes);
     }

--- a/src/url_rule.rs
+++ b/src/url_rule.rs
@@ -15,6 +15,7 @@ pub struct UrlMatcher {
     fragment: String,
 }
 
+#[derive(Clone, Debug)]
 pub struct UrlGlobMatcher {
     scheme: GlobMatcher,
     hostname: GlobMatcher,
@@ -87,8 +88,7 @@ impl UrlGlobMatcher {
         //self.scheme.is_match_candidate()
         let scheme_matches = self.scheme.is_match(target_url.scheme);
 
-        let target_hostname_with_slashes = target_url.hostname.replace(".", "/");
-        let hostname_matches = self.hostname.is_match(target_hostname_with_slashes);
+        let hostname_matches = self.hostname_matches(target_url.hostname.as_str());
         let path_matches = self.path.is_match(target_url.path);
 
         let target_query_with_slashes = target_url.query.replace("&", "/");
@@ -100,6 +100,11 @@ impl UrlGlobMatcher {
             && path_matches
             && query_matches
             && fragment_matches;
+    }
+
+    pub fn hostname_matches(&self, target_hostname: &str) -> bool {
+        let target_hostname_with_slashes = target_hostname.replace(".", "/");
+        return self.hostname.is_match(target_hostname_with_slashes);
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,22 +1,22 @@
-use std::{fs, u32};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
+use std::{fs, u32};
 
 use druid::image;
-use druid::image::{ImageFormat, Rgba};
 use druid::image::imageops::FilterType;
+use druid::image::{ImageFormat, Rgba};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use crate::{InstalledBrowser, paths, SupportedAppRepository};
 #[cfg(target_os = "linux")]
 use crate::linux_utils;
 #[cfg(target_os = "macos")]
 use crate::macos_utils;
 #[cfg(target_os = "windows")]
 use crate::windows_utils;
+use crate::{paths, InstalledBrowser, SupportedAppRepository};
 
 #[cfg(target_os = "macos")]
 pub fn set_as_default_web_browser() -> bool {
@@ -149,7 +149,7 @@ impl OSAppFinder {
             ("figma", vec!["figma.com", "www.figma.com"]),
             ("linear", vec!["linear.app"]),
             ("notion", vec!["notion.so", "www.notion.so"]),
-            ("slack", vec!["*.slack.com"]),
+            ("slack", vec!["*.slack.com", "*.enterprise.slack.com"]),
             ("spotify", vec!["open.spotify.com"]),
             ("tg", vec!["t.me"]), // telegram
             (

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -149,6 +149,7 @@ impl OSAppFinder {
             ("figma", vec!["figma.com", "www.figma.com"]),
             ("linear", vec!["linear.app"]),
             ("notion", vec!["notion.so", "www.notion.so"]),
+            ("slack", vec!["*.slack.com"]),
             ("spotify", vec!["open.spotify.com"]),
             ("tg", vec!["t.me"]), // telegram
             (
@@ -169,10 +170,10 @@ impl OSAppFinder {
         ];
         let schemes_vec: Vec<(String, Vec<String>)> = schemes
             .iter()
-            .map(|(scheme, domains)| {
+            .map(|(scheme, domain_patterns)| {
                 (
                     scheme.to_string(),
-                    domains.iter().map(|d| d.to_string()).collect(),
+                    domain_patterns.iter().map(|d| d.to_string()).collect(),
                 )
             })
             .collect();

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -250,14 +250,17 @@ impl OsHelper {
             .map(|path_perhaps| Path::new(path_perhaps))
             .unwrap_or(Path::new("unknown"));
 
-        let profiles = supported_app.find_profiles(executable_path_best_guess.clone(), false);
+        let profiles =
+            supported_app.find_profiles(executable_path_best_guess.clone(), false, false);
 
         let browser = InstalledBrowser {
             command: command_parts.clone(),
             executable_path: executable_path_best_guess.to_str().unwrap().to_string(),
             display_name: display_name.to_string(),
             bundle: app_id.to_string(),
-            user_dir: supported_app.get_app_config_dir_absolute(false).to_string(),
+            user_dir: supported_app
+                .get_app_config_dir_absolute(false, false)
+                .to_string(),
             icon_path: icon_path_str.clone(),
             profiles: profiles,
             restricted_domains: restricted_domains,


### PR DESCRIPTION
Support Slack application when clicking on `https://<your-team>slack.com` url.
Support sandboxed and unsandboxed slack application.
Support filtering application profiles by opened url (so far the filter was only for the whole application, Slack is the first profile-enabled non-browser app).