### PR TITLE
windows: static link vcruntime140.dll

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@
 #target = "aarch64-pc-windows-msvc"
 #target = "aarch64-unknown-linux-gnu"
 #target = "aarch64-apple-darwin"
+
+#[target.'cfg(all(windows, target_env = "msvc"))']
+#rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "single-instance",
+ "static_vcruntime",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1854,6 +1855,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_vcruntime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954e3e877803def9dc46075bf4060147c55cd70db97873077232eae0269dc89b"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ dunce = "1.0.4"
 # Requires rc.exe from the Windows SDK (or windres.exe and ar.exe from minGW64)
 winres = "0.1.12"
 
+# statically link vcruntime140.dll instead of requiring user to install the runtime
+static_vcruntime = "2.0"
+
 #[profile.dev]
 #lto = true
 

--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,9 @@ fn main() {
     let mut res = winres::WindowsResource::new();
     res.set_icon("extra/windows/icons/browsers.ico");
     res.compile().unwrap();
+
+    // statically link vcruntime140.dll instead of requiring user to install the runtime
+    static_vcruntime::metabuild();
 }
 
 #[cfg(target_os = "linux")]

--- a/extra/windows/dist/install.bat
+++ b/extra/windows/dist/install.bat
@@ -57,11 +57,17 @@ if "%~1"=="--user" (
   set is_explicitly_requested_user=false
 )
 
-if %is_admin% == true if not %is_explicitly_requested_user% == true (
-  echo Because you are running this as an administrator we are going to install it to the whole system
-  echo Please run this installer with --user flag to override this behaviour.
-  echo.
-  set is_local_install=false
+REM Default to system-wide install if running with admin rights and
+REM not specifying explicit user/system install mode
+if %is_admin% == true (
+    if not %is_explicitly_requested_user% == true (
+        if not %is_explicitly_requested_system% == true (
+          echo Because you are running this as an administrator we are going to install it to the whole system
+          echo Please run this installer with --user flag to override this behaviour.
+          echo.
+          set is_local_install=false
+        )
+    )
 )
 
 REM C:\Users\x\AppData\Local\software.Browsers\
@@ -72,8 +78,10 @@ if %is_local_install% == true (
     setlocal EnableDelayedExpansion
     set ProgramDir=!LocalProgramsDir!\software.Browsers
     setlocal DisableDelayedExpansion
+    echo Installing only for current user
 ) else (
     set ProgramDir=%ProgramFiles%\software.Browsers
+    echo Installing for all users
 )
 
 echo Installing to %ProgramDir%

--- a/extra/windows/dist/install.bat
+++ b/extra/windows/dist/install.bat
@@ -25,9 +25,9 @@ if not exist "%windir%\system32\vcruntime140.dll" (
     exit /b 1
 )
 
-if exist "%windir%\system32\config\systemprofile\*" (
+fltmc >nul 2>&1 && (
   set is_admin=true
-) else (
+) || (
   set is_admin=false
 )
 

--- a/extra/windows/dist/install.bat
+++ b/extra/windows/dist/install.bat
@@ -171,15 +171,16 @@ REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\App Paths\brow
 REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\App Paths\browsers.exe\SupportedProtocols" /v https /t REG_SZ /d "" /f 1>nul
 
 REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /f 1>nul
-REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v DisplayName /t REG_SZ /d "Browsers" /f 1>nul
 REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v DisplayIcon /t REG_SZ /d "%ProgramDir%\browsers.exe" /f 1>nul
 REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v DisplayVersion /t REG_SZ /d "0.0.0" /f 1>nul
 REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v EstimatedSize /t REG_DWORD /d 4800 /f 1>nul
 REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v Publisher /t REG_SZ /d "Browsers.software" /f 1>nul
 
 if %is_local_install% == true (
+  REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v DisplayName /t REG_SZ /d "Browsers (Current User)" /f 1>nul
   REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v UninstallString /t REG_SZ /d "\"%ProgramDir%\uninstall.bat\" --user" /f 1>nul
 ) else (
+  REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v DisplayName /t REG_SZ /d "Browsers (All Users)" /f 1>nul
   REG ADD "%RegistryRoot%\Software\Microsoft\Windows\CurrentVersion\Uninstall\software.Browsers" /v UninstallString /t REG_SZ /d "\"%ProgramDir%\uninstall.bat\" --system" /f 1>nul
 )
 


### PR DESCRIPTION
Remove dependency on `vcruntime140.dll` and statically link the used functions in the binary.

Use alternative way to check for admin elevation