### PR TITLE
browser_repository.rs: Fix Firefox incognito argument

### DIFF
--- a/src/browser_repository.rs
+++ b/src/browser_repository.rs
@@ -455,7 +455,7 @@ impl SupportedAppRepository {
             profile_args_fn: |profile_cli_arg_value| {
                 vec![format!("--profile-directory={}", profile_cli_arg_value)]
             },
-            incognito_args: vec!["-incognito".to_string()],
+            incognito_args: vec!["--incognito".to_string()],
             url_transform_fn: chromium_url_transform_fn,
             url_as_first_arg: true,
         }
@@ -493,7 +493,7 @@ impl SupportedAppRepository {
             profile_args_fn: |profile_cli_arg_value| {
                 vec!["-P".to_string(), profile_cli_arg_value.to_string()]
             },
-            incognito_args: vec!["-private".to_string()],
+            incognito_args: vec!["--private-window".to_string()],
             url_transform_fn: firefox_url_transform_fn,
             url_as_first_arg: true,
         }


### PR DESCRIPTION
This should not be `--private`, but `--private-window`. Probably explains why opening in incognito mode (when holding shift) does not work for me for Firefox profiles :stuck_out_tongue: 

Also, I changed the incognito arguments for both Chrome and Firefox to use the canonical double dash instead of single dash.

P.S.: Since I don't need a Rust toolchain set up on my machine, I don't want to use https://aur.archlinux.org/packages/browsers-git, so I created https://aur.archlinux.org/packages/browsers-bin. Let me know if I need to transfer ownership to you, but I'm happy to bump the version number once in a while :slightly_smiling_face: 