### PR TITLE
install.sh: Remove --rebuild-mime-info-cache-flag

### DIFF
--- a/extra/linux/dist/install.sh
+++ b/extra/linux/dist/install.sh
@@ -166,7 +166,7 @@ install_desktop_file() {
   fi
 
   # Copy .desktop file to $HOME/.local/share/applications/ or /usr/share/applications
-  desktop-file-install --dir="$TARGET_DESKTOP_DIR_PATH" --rebuild-mime-info-cache "$SRC_DESKTOP_FILE_PATH"
+  desktop-file-install --dir="$TARGET_DESKTOP_DIR_PATH" "$SRC_DESKTOP_FILE_PATH"
 }
 
 install_xfce4_desktop_file() {
@@ -207,7 +207,6 @@ install_binary
 install_icons
 install_xfce4_desktop_file
 install_desktop_file
-
 
 if [[ $* != *--skip-desktop-database* ]]; then
   # The update-desktop-database program is a tool to build a cache database of the MIME types handled by desktop files.


### PR DESCRIPTION
This flag does the same as the `update-desktop-database` command near the end of this script, which has been made optional with the `--skip-desktop-database` flag.

I had to add https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=browsers-bin#n23 to get the AUR package to work. :innocent: (side-note, I just realized that the [`browser-git` package in the AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=browsers-git) did not have problems with the MIME cache, because it doesn't run `install.sh`, but manually copies the files instead.)