### PR TITLE
Consistent argument order: first profile, then incognito, then URL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,16 +143,15 @@ impl BrowserCommon {
             }
 
             arguments.arg("--args");
-            if !profile_args.is_empty() {
-                arguments.args(profile_args);
-            }
-            if self.supported_app.is_url_as_first_arg() {
-                arguments.arg(app_url.clone());
-            }
+            arguments.args(profile_args);
 
             if incognito_mode && self.supported_app.supports_incognito() {
                 let incognito_args = self.supported_app.get_incognito_args();
                 arguments.args(incognito_args);
+            }
+
+            if self.supported_app.is_url_as_first_arg() {
+                arguments.arg(app_url.clone());
             }
 
             debug!("Launching: {:?}", cmd);
@@ -178,13 +177,14 @@ impl BrowserCommon {
 
             let mut cmd = Command::new(main_command.to_string());
 
-            cmd.args(arguments);
             cmd.args(profile_args);
 
             if incognito_mode && self.supported_app.supports_incognito() {
                 let incognito_args = self.supported_app.get_incognito_args();
                 cmd.args(incognito_args);
             }
+
+            cmd.args(arguments);
 
             // Non-browser apps don't have the placeholder
             if !has_url_placeholder {


### PR DESCRIPTION
Turns out that Firefox requires the URL to come _after_ the `--private-window` argument. If you run Firefox with the incorrect order, e.g. `firefox <url> --profile <profile> --private-window`, Firefox will open `<url>` in a non-private window, and subsequently opens an empty private window. :sweat_smile: 

I only tested on Linux, not on Mac or Windows, but in any case, I don't think it would hurt if we make the argument order consistent across the three platforms. Although a counter-argument to that would be the hack-around for Safari (which apparently requires the URL to be the _first_ argument :stuck_out_tongue:).

And there's one other thing I'm not 100% sure of: Linux desktop entries for browsers typically include a `%u` (or `%U`) argument, and this PR bluntly inserts the profile and incognito arguments directly after the `main_command`. This should™ work fine for most browsers, since their command format is simply `<browser_cmd> %u` in most cases (this is at least the case for Chrome, Epiphany, and Firefox, according to my `.cache/software.Browsers/installed_browsers.json`).

Let me know if I overlooked anything :slightly_smiling_face: 

P.S. I removed the `if !profile_args.is_empty()` check from the `macos` case, since the other platforms also do not have this. Appending an empty vector to `args` shouldn't do anything anyway :slightly_smiling_face: 