### PR TITLE
linux: don't use gtk for parsing .desktop files and icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           target_dir='target/universal-apple-darwin/release'
           cd "$target_dir"
           set -x
-          open ./Browsers.app -u https://browsers.software --stdout /tmp/my-stdout --args --no-gui && cat /tmp/my-stdout
+          open ./Browsers.app --stdout /tmp/my-stdout --stderr /tmp/my-stderr --args --no-gui https://browsers.software && cat /tmp/my-stdout && cat /tmp/my-stderr
         shell: bash
       - name: Upload mac artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           target_dir='target/universal-apple-darwin/release'
           cd "$target_dir"
           set -x
-          open ./Browsers.app --stdout /tmp/my-stdout --stderr /tmp/my-stderr --args --no-gui https://browsers.software && cat /tmp/my-stdout && cat /tmp/my-stderr
+          open ./Browsers.app --env BROWSERS_LOG_LEVEL=DEBUG --stdout /tmp/my-stdout --stderr /tmp/my-stderr --args --no-gui https://browsers.software && cat /tmp/my-stdout && cat /tmp/my-stderr
         shell: bash
       - name: Upload mac artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
       - name: End-to-end test - run Browsers
         run: |
           set
-          install_dir="$ProgramFiles/software.Browsers"
+          install_dir="$PROGRAMFILES/software.Browsers"
           cd "$install_dir"
           ./browsers.exe --no-gui https://browsers.software
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,12 @@ jobs:
           set -x
           ./install.sh
         shell: bash
-      #- name: End-to-end test - run Browsers
-      #  run: |
-      #    install_dir="$HOME/.local/bin"
-      #    cd "$install_dir"
-      #    ./browsers --no-gui https://browsers.software
-      #  shell: bash
+      - name: End-to-end test - run Browsers
+        run: |
+          install_dir="$HOME/.local/bin"
+          cd "$install_dir"
+          ./browsers --no-gui https://browsers.software
+        shell: bash
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,7 @@ jobs:
         shell: bash
       - name: End-to-end test - run Browsers
         run: |
+          set
           install_dir="$ProgramFiles/software.Browsers"
           cd "$install_dir"
           ./browsers.exe --no-gui https://browsers.software

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,12 @@ jobs:
           set -x
           ./install.bat --silent
         shell: bash
+      - name: End-to-end test - run Browsers
+        run: |
+          install_dir="%ProgramFiles%/software.Browsers"
+          cd "$install_dir"
+          ./browsers.exe --no-gui https://browsers.software
+        shell: bash
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
         shell: bash
       - name: End-to-end test - run Browsers
         run: |
-          install_dir="%ProgramFiles%/software.Browsers"
+          install_dir="$ProgramFiles/software.Browsers"
           cd "$install_dir"
           ./browsers.exe --no-gui https://browsers.software
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,9 +197,11 @@ dependencies = [
  "cocoa-foundation",
  "configparser",
  "core-foundation",
- "dirs",
+ "dirs 5.0.1",
  "druid",
  "dunce",
+ "freedesktop-desktop-entry",
+ "freedesktop-icons",
  "gio",
  "globset",
  "gtk",
@@ -396,6 +398,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,11 +510,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -497,6 +534,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -531,6 +579,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.50",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -762,6 +819,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "freedesktop-desktop-entry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45157175a725e81f3f594382430b6b78af5f8f72db9bd51b94f0785f80fc6d29"
+dependencies = [
+ "dirs 3.0.2",
+ "gettext-rs",
+ "memchr",
+ "thiserror",
+ "xdg",
+]
+
+[[package]]
+name = "freedesktop-icons"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5339cbd60b2ff6b95ef212ab96bc80bf1a9dff2821b9966c417cdfae2808796"
+dependencies = [
+ "dirs 5.0.1",
+ "once_cell",
+ "rust-ini",
+ "thiserror",
+ "xdg",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +985,26 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gettext-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49ea8a8fad198aaa1f9655a2524b64b70eb06b2f3ff37da407566c93054f364"
+dependencies = [
+ "gettext-sys",
+ "locale_config",
+]
+
+[[package]]
+name = "gettext-sys"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63ce2e00f56a206778276704bbe38564c8695249fdc8f354b4ef71c57c3839d"
+dependencies = [
+ "cc",
+ "temp-dir",
 ]
 
 [[package]]
@@ -1248,6 +1351,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "locale_config"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
+dependencies = [
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "regex",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1508,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1538,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
 
 [[package]]
 name = "overload"
@@ -1682,6 +1828,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1860,16 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rolling-file"
 version = "0.2.0"
 source = "git+https://github.com/browsers-software/rolling-file-rs.git?branch=browsers#1e187f7aa3af6286ef1029bc1beed0c0993a6630"
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1909,6 +2077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
+name = "temp-dir"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd16aa9ffe15fe021c6ee3766772132c6e98dfa395a167e16864f61a9cfb71d6"
+
+[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2143,15 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2572,6 +2755,12 @@ checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xdg-mime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,6 @@ dependencies = [
  "freedesktop-icons",
  "gio",
  "globset",
- "gtk",
  "interprocess",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-icons"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5339cbd60b2ff6b95ef212ab96bc80bf1a9dff2821b9966c417cdfae2808796"
+checksum = "a8ef34245e0540c9a3ce7a28340b98d2c12b75da0d446da4e8224923fcaa0c16"
 dependencies = [
  "dirs 5.0.1",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,12 @@ xdg-mime = "^0.3.3"
 # to find default registered icons
 glib = { version = "0.16.6", package = "gio" }
 
+# to find application .desktop files
+freedesktop-desktop-entry = "0.5.0"
+
+# to find icon theme and icon;
+freedesktop-icons = "0.2.5"
+
 # to find icon theme and icon; (should be same version of gtk as druid is using)
 gtk = { version = "0.16.2" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,6 @@ freedesktop-desktop-entry = "0.5.0"
 # to find icon theme and icon;
 freedesktop-icons = "0.2.5"
 
-# to find icon theme and icon; (should be same version of gtk as druid is using)
-gtk = { version = "0.16.2" }
-
 # Helps parsing commands that are in Exec field in .desktop files
 shell-words = "1.1.0"
 

--- a/cross/Dockerfile.linux_aarch64
+++ b/cross/Dockerfile.linux_aarch64
@@ -1,8 +1,14 @@
 FROM --platform=linux/amd64 ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 
-RUN dpkg --add-architecture arm64 \
-    && DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-    libpango-1.0-0:arm64 \
-    libpango1.0-dev:arm64 \
-    libgtk-3-dev:arm64
+RUN dpkg --add-architecture arm64 && \
+    DEBIAN_FRONTEND=noninteractive apt-get \
+      -o Acquire::CompressionTypes::Order::=gz \
+      update && \
+    DEBIAN_FRONTEND=noninteractive apt-get \
+      -o Acquire::CompressionTypes::Order::=gz \
+      -y \
+      --no-install-recommends \
+      install \
+        libpango-1.0-0:arm64 \
+        libpango1.0-dev:arm64 \
+        libgtk-3-dev:arm64

--- a/cross/Dockerfile.linux_armv7
+++ b/cross/Dockerfile.linux_armv7
@@ -1,8 +1,14 @@
 FROM --platform=linux/amd64 ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
 
-RUN dpkg --add-architecture armhf \
-    && DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-    libpango-1.0-0:armhf \
-    libpango1.0-dev:armhf \
-    libgtk-3-dev:armhf
+RUN dpkg --add-architecture armhf && \
+    DEBIAN_FRONTEND=noninteractive apt-get \
+      -o Acquire::CompressionTypes::Order::=gz \
+      update && \
+    DEBIAN_FRONTEND=noninteractive apt-get \
+      -o Acquire::CompressionTypes::Order::=gz \
+      -y \
+      --no-install-recommends \
+      install \
+        libpango-1.0-0:armhf \
+        libpango1.0-dev:armhf \
+        libgtk-3-dev:armhf

--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -210,7 +210,7 @@ os = "MAC"
 id = "vivaldi-stable"
 config_dir_relative = "vivaldi"
 kind = "CHROMIUM"
-os = "MAC"
+os = "LINUX"
 
 [[apps]]
 id = "com.vivaldi.Vivaldi.snapshot"
@@ -360,7 +360,7 @@ kind = "TELEGRAM"
 os = "LINUX"
 
 [[apps]]
-id = "com.workflowy"
+id = "com.workflowy.desktop"
 kind = "WORKFLOWY"
 os = "MAC"
 

--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -5,7 +5,7 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "google-chrome.desktop"
+id = "google-chrome"
 config_dir_relative = "google-chrome"
 kind = "CHROMIUM"
 os = "LINUX"
@@ -23,7 +23,7 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "google-chrome-beta.desktop"
+id = "google-chrome-beta"
 config_dir_relative = "google-chrome-beta"
 kind = "CHROMIUM"
 os = "LINUX"
@@ -35,7 +35,7 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "google-chrome-dev.desktop"
+id = "google-chrome-dev"
 config_dir_relative = "google-chrome-dev"
 kind = "CHROMIUM"
 os = "LINUX"
@@ -47,7 +47,7 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "google-chrome-canary.desktop"
+id = "google-chrome-canary"
 config_dir_relative = "google-chrome-canary"
 kind = "CHROMIUM"
 os = "LINUX"
@@ -59,21 +59,21 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "chromium.desktop"
+id = "chromium"
 config_dir_relative = "google-chrome-canary"
 snap_dir = "chromium"
 kind = "CHROMIUM"
 os = "LINUX"
 
 [[apps]]
-id = "chromium_chromium.desktop"
+id = "chromium_chromium"
 config_dir_relative = "google-chrome-canary"
 snap_dir = "chromium"
 kind = "CHROMIUM"
 os = "LINUX"
 
 [[apps]]
-id = "chromium-browser.desktop"
+id = "chromium-browser"
 config_dir_relative = "google-chrome-canary"
 snap_dir = "chromium"
 kind = "CHROMIUM"
@@ -152,7 +152,7 @@ kind = "CHROMIUM"
 os = "WINDOWS"
 
 [[apps]]
-id = "microsoft-edge-dev.desktop"
+id = "microsoft-edge-dev"
 config_dir_relative = "microsoft-edge-dev"
 kind = "CHROMIUM"
 os = "LINUX"
@@ -176,7 +176,7 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "brave-browser.desktop"
+id = "brave-browser"
 config_dir_relative = "BraveSoftware/Brave-Browser"
 snap_dir = "brave"
 kind = "CHROMIUM"
@@ -207,7 +207,7 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
-id = "vivaldi-stable.desktop"
+id = "vivaldi-stable"
 config_dir_relative = "vivaldi"
 kind = "CHROMIUM"
 os = "MAC"
@@ -237,21 +237,21 @@ kind = "FIREFOX"
 os = "MAC"
 
 [[apps]]
-id = "firefox.desktop"
+id = "firefox"
 config_dir_relative = ".mozilla/firefox"
 snap_dir = "firefox"
 kind = "FIREFOX"
 os = "LINUX"
 
 [[apps]]
-id = "firefox_firefox.desktop"
+id = "firefox_firefox"
 config_dir_relative = ".mozilla/firefox"
 snap_dir = "firefox"
 kind = "FIREFOX"
 os = "LINUX"
 
 [[apps]]
-id = "firefox-esr.desktop"
+id = "firefox-esr"
 config_dir_relative = ".mozilla/firefox"
 snap_dir = "firefox"
 kind = "FIREFOX"
@@ -322,7 +322,7 @@ kind = "SLACK"
 os = "MAC"
 
 [[apps]]
-id = "slack.desktop"
+id = "slack"
 config_dir_relative = "Slack"
 snap_dir = "slack"
 kind = "SLACK"
@@ -340,7 +340,7 @@ kind = "SPOTIFY"
 os = "MAC"
 
 [[apps]]
-id = "spotify_spotify.desktop"
+id = "spotify_spotify"
 kind = "SPOTIFY"
 os = "LINUX"
 
@@ -355,12 +355,12 @@ kind = "TELEGRAM"
 os = "MAC"
 
 [[apps]]
-id = "telegram-desktop_telegram-desktop.desktop"
+id = "telegram-desktop_telegram-desktop"
 kind = "TELEGRAM"
 os = "LINUX"
 
 [[apps]]
-id = "com.workflowy.desktop"
+id = "com.workflowy"
 kind = "WORKFLOWY"
 os = "MAC"
 
@@ -375,7 +375,7 @@ kind = "ZOOM"
 os = "MAC"
 
 [[apps]]
-id = "Zoom.desktop"
+id = "Zoom"
 kind = "ZOOM"
 os = "LINUX"
 

--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -60,21 +60,21 @@ os = "MAC"
 
 [[apps]]
 id = "chromium"
-config_dir_relative = "google-chrome-canary"
+config_dir_relative = "chromium"
 snap_dir = "chromium"
 kind = "CHROMIUM"
 os = "LINUX"
 
 [[apps]]
 id = "chromium_chromium"
-config_dir_relative = "google-chrome-canary"
+config_dir_relative = "chromium"
 snap_dir = "chromium"
 kind = "CHROMIUM"
 os = "LINUX"
 
 [[apps]]
 id = "chromium-browser"
-config_dir_relative = "google-chrome-canary"
+config_dir_relative = "chromium"
 snap_dir = "chromium"
 kind = "CHROMIUM"
 os = "LINUX"

--- a/src/browser_repository.rs
+++ b/src/browser_repository.rs
@@ -679,10 +679,6 @@ impl SupportedApp {
         };
     }
 
-    pub fn supports_profiles(&self) -> bool {
-        return self.find_profiles_fn.is_some();
-    }
-
     pub fn get_profile_args(&self, profile_cli_arg_value: &str) -> Vec<String> {
         return (self.profile_args_fn)(profile_cli_arg_value);
     }

--- a/src/gui/linux_ui.rs
+++ b/src/gui/linux_ui.rs
@@ -1,4 +1,4 @@
 pub fn init_gtk() {
     // must be initialized in main thread (because of gtk requirements)
-    gtk::init().expect("Could not initialize gtk");
+    //gtk::init().expect("Could not initialize gtk");
 }

--- a/src/gui/linux_ui.rs
+++ b/src/gui/linux_ui.rs
@@ -1,0 +1,4 @@
+pub fn init_gtk() {
+    // must be initialized in main thread (because of gtk requirements)
+    let _result = gtk::init().expect("Could not initialize gtk");
+}

--- a/src/gui/linux_ui.rs
+++ b/src/gui/linux_ui.rs
@@ -1,4 +1,4 @@
 pub fn init_gtk() {
     // must be initialized in main thread (because of gtk requirements)
-    let _result = gtk::init().expect("Could not initialize gtk");
+    gtk::init().expect("Could not initialize gtk");
 }

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -65,21 +65,16 @@ impl FocusData for ((bool, UISettings), UIBrowser) {
     }
 }
 
-pub struct MainWindow {
-    filtered_browsers: Arc<Vec<UIBrowser>>,
-    show_set_as_default: bool,
-}
+pub struct MainWindow {}
 
 impl MainWindow {
-    pub fn new(filtered_browsers: Arc<Vec<UIBrowser>>, show_set_as_default: bool) -> Self {
-        Self {
-            filtered_browsers: filtered_browsers,
-            show_set_as_default: show_set_as_default,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn create_main_window(
         self,
+        browser_count: usize,
         mouse_position: &Point,
         monitor: &Monitor,
     ) -> WindowDesc<UIState> {
@@ -89,7 +84,6 @@ impl MainWindow {
             // add some spacing around screen
             .inflate(-5f64, -5f64);
 
-        let browser_count = (&self.filtered_browsers).len();
         let window_size = recalculate_window_size(browser_count);
         let window_position =
             calculate_window_position(&mouse_position, &screen_rect, &window_size);
@@ -155,8 +149,6 @@ impl MainWindow {
             .fix_width(OPTIONS_LABEL_SIZE)
             .fix_height(OPTIONS_LABEL_SIZE);
 
-        let show_set_as_default = self.show_set_as_default;
-
         let options_button = FocusWidget::new(
             options_label,
             |ctx, _data: &UIState, _env| {
@@ -184,7 +176,7 @@ impl MainWindow {
             );
 
             ctx.show_context_menu(
-                make_options_menu(show_set_as_default, data.restorable_app_profiles.clone()),
+                make_options_menu(data.show_set_as_default, data.restorable_app_profiles.clone()),
                 position,
             );
         })

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,4 +6,7 @@ pub mod settings_window;
 pub mod ui;
 pub mod ui_util;
 
+#[cfg(target_os = "linux")]
+pub mod linux_ui;
+
 pub mod shared;

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -108,10 +108,10 @@ impl UI {
                 restricted_url_matchers: Arc::new(p.get_restricted_url_matchers().clone()),
                 browser_name: p.get_browser_name().to_string(),
                 profile_name: p.get_profile_name().to_string(),
-                supports_profiles: p.get_browser_common().supports_profiles(),
+                supports_profiles: p.get_browser_common().has_real_profiles(),
                 profile_name_maybe: p
                     .get_browser_common()
-                    .supports_profiles()
+                    .has_real_profiles()
                     .then(|| p.get_profile_name().to_string()),
                 supports_incognito: p.get_browser_common().supports_incognito(),
                 icon_path: p.get_browser_icon_path().to_string(),
@@ -472,8 +472,8 @@ impl AppDelegate<UIState> for UIDelegate {
 
         let should_exit = match event {
             Event::KeyDown(KeyEvent {
-                key: KbKey::Escape, ..
-            }) => true,
+                               key: KbKey::Escape, ..
+                           }) => true,
             Event::WindowLostFocus => quit_on_lost_focus,
             _ => false,
         };
@@ -505,17 +505,17 @@ impl AppDelegate<UIState> for UIDelegate {
 
         // Cmd+C on macOS, Ctrl+C on windows/linux/OpenBSD
         #[cfg(target_os = "macos")]
-        let copy_key_mod = Modifiers::META;
+            let copy_key_mod = Modifiers::META;
 
         #[cfg(not(target_os = "macos"))]
-        let copy_key_mod = Modifiers::CONTROL;
+            let copy_key_mod = Modifiers::CONTROL;
 
         match event {
             Event::KeyDown(KeyEvent {
-                key: KbKey::Character(ref key),
-                ref mods,
-                ..
-            }) if key == "c" && mods == &copy_key_mod => {
+                               key: KbKey::Character(ref key),
+                               ref mods,
+                               ..
+                           }) if key == "c" && mods == &copy_key_mod => {
                 debug!("Cmd/Ctrl+C caught in delegate");
                 ctx.get_external_handle()
                     .submit_command(COPY_LINK_TO_CLIPBOARD, {}, Target::Global)
@@ -523,10 +523,10 @@ impl AppDelegate<UIState> for UIDelegate {
             }
 
             Event::KeyDown(KeyEvent {
-                key: KbKey::Character(ref key),
-                ref mods,
-                ..
-            }) if key == "," && mods == &copy_key_mod => {
+                               key: KbKey::Character(ref key),
+                               ref mods,
+                               ..
+                           }) if key == "," && mods == &copy_key_mod => {
                 debug!("Cmd/Ctrl+, caught in delegate");
                 ctx.get_external_handle()
                     .submit_command(SHOW_SETTINGS_DIALOG, {}, Target::Global)
@@ -626,7 +626,7 @@ impl AppDelegate<UIState> for UIDelegate {
                 (window_size, window_position),
                 target_window,
             )
-            .unwrap();
+                .unwrap();
 
             // After current event has been handled, bring the window to the front, and give it focus.
             // Normally not needed, but if About menu was opened, then window would not have appeared
@@ -692,7 +692,7 @@ impl AppDelegate<UIState> for UIDelegate {
                 (window_size, window_position),
                 target_window,
             )
-            .unwrap();
+                .unwrap();
 
             Handled::Yes
         } else if cmd.is(NEW_HIDDEN_BROWSERS_RECEIVED) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ impl BrowserCommon {
         return self.executable_path.to_string();
     }
 
-    fn supports_profiles(&self) -> bool {
-        return self.supported_app.supports_profiles();
+    fn has_real_profiles(&self) -> bool {
+        self.profiles_type == InstalledAppProfilesType::RealProfiles
     }
 
     fn supports_incognito(&self) -> bool {
@@ -398,7 +398,7 @@ impl InstalledAppProfiles {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 enum InstalledAppProfilesType {
     RealProfiles,
     PlaceholderProfiles,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,7 +623,9 @@ pub fn basically_main(
 
     // must be initialized in main thread (because of gtk requirements)
     #[cfg(target_os = "linux")]
-    gui::linux_ui::init_gtk();
+    if show_gui {
+        gui::linux_ui::init_gtk();
+    }
 
     let launcher = ui2.create_app_launcher();
     let ui_event_sink = launcher.get_external_handle();
@@ -874,6 +876,8 @@ pub fn basically_main(
 
     if show_gui {
         launcher.launch(initial_ui_state).expect("error");
+    } else {
+        ui2.print_visible_options();
     }
 }
 

--- a/src/linux/linux_utils.rs
+++ b/src/linux/linux_utils.rs
@@ -89,17 +89,20 @@ impl OsHelper {
 
         // collect all .desktop file paths and map them by file name to remove duplicate files,
         // even if they exist in different directories
-        let mut desktop_file_paths_by_filename: BTreeMap<_, _> = Iter::new(all_search_paths)
-            .map(|file_path| {
-                let option1 = file_path.file_name();
-                let option = option1.map(|a| a.to_owned());
-                (option, file_path)
+        let mut desktop_file_paths_by_filename: BTreeMap<_, PathBuf> = Iter::new(all_search_paths)
+            .filter_map(|file_path| {
+                file_path
+                    .file_name()
+                    .map(|a| a.to_owned())
+                    .map(|file_name| (file_name, file_path))
             })
             .collect();
 
-        let cleaned_desktop_file_paths = desktop_file_paths_by_filename.into_values().collect();
+        let cleaned_desktop_file_paths: Vec<PathBuf> =
+            desktop_file_paths_by_filename.into_values().collect();
 
-        let vec = Iter::new(cleaned_desktop_file_paths)
+        let vec = cleaned_desktop_file_paths
+            .iter()
             .filter_map(|desktop_file_path| {
                 Self::read_desktop_entry_matching(&desktop_file_path.as_path(), content_type)
             })

--- a/src/linux/linux_utils.rs
+++ b/src/linux/linux_utils.rs
@@ -1,17 +1,10 @@
 use std::fs;
-use std::fs::File;
-use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 
 use druid::image;
 use druid::image::ImageFormat;
-use freedesktop_desktop_entry::DesktopEntry;
+use freedesktop_desktop_entry::{default_paths, DesktopEntry, Iter};
 use freedesktop_icons;
-use glib::prelude::AppInfoExt;
-use glib::AppInfo;
-use gtk::prelude::*;
-use gtk::{gio, IconLookupFlags, IconTheme};
 use tracing::{info, warn};
 
 use crate::{InstalledBrowser, SupportedAppRepository};
@@ -35,9 +28,7 @@ pub struct OsHelper {
 unsafe impl Send for OsHelper {}
 
 impl OsHelper {
-    // must be initialized in main thread (because of gtk requirements)
     pub fn new() -> OsHelper {
-        let _result = gtk::init().expect("Could not initialize gtk");
         let app_repository = SupportedAppRepository::new();
         Self {
             app_repository: app_repository,
@@ -53,8 +44,6 @@ impl OsHelper {
         &self,
         schemes: Vec<(String, Vec<String>)>,
     ) -> Vec<InstalledBrowser> {
-        let mut browsers: Vec<InstalledBrowser> = Vec::new();
-
         let cache_root_dir = get_this_app_cache_root_dir();
         let icons_root_dir = cache_root_dir.join("icons");
         fs::create_dir_all(icons_root_dir.as_path()).unwrap();
@@ -62,23 +51,23 @@ impl OsHelper {
         let desktop_entry_holders: Vec<(DesktopEntryHolder, Vec<String>)> = schemes
             .iter()
             .map(|(scheme, domains)| {
-                let content_type = format!("x-scheme-handler/{scheme}").as_str();
+                let content_type = format!("x-scheme-handler/{scheme}");
                 let desktop_entry_holders =
-                    Self::freedesktop_find_all_desktop_entries(content_type);
-
-                //let desktop_entry_holders = Self::glib_find_all_desktop_entries(content_type);
+                    Self::freedesktop_find_all_desktop_entries(content_type.as_str());
 
                 (desktop_entry_holders, domains)
             })
             .flat_map(|(desktop_entry_holders, domains)| {
-                let app_info_and_domains: Vec<(AppInfo, Vec<String>)> = desktop_entry_holders
-                    .iter()
-                    .map(|app_info| (app_info.clone(), domains.clone()))
-                    .collect();
+                let app_info_and_domains: Vec<(DesktopEntryHolder, Vec<String>)> =
+                    desktop_entry_holders
+                        .iter()
+                        .map(|app_info| (app_info.clone(), domains.clone()))
+                        .collect();
                 app_info_and_domains
             })
             .collect();
 
+        let mut browsers: Vec<InstalledBrowser> = Vec::new();
         for (desktop_entry_holder, domains) in desktop_entry_holders {
             let browser_maybe =
                 self.to_installed_browser(&desktop_entry_holder, icons_root_dir.as_path(), domains);
@@ -91,29 +80,41 @@ impl OsHelper {
     }
 
     fn freedesktop_find_all_desktop_entries(content_type: &str) -> Vec<DesktopEntryHolder> {
-        let entry_holders: Vec<DesktopEntryHolder> =
-            freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths())
-                .filter_map(|desktop_file_path| {
-                    if let Ok(bytes) = fs::read_to_string(&desktop_file_path) {
-                        if let Ok(entry) = DesktopEntry::decode(&desktop_file_path, &bytes) {
-                            if let Some(mime_type_str) = entry.mime_type() {
+        let all_search_paths = default_paths();
+
+        return Iter::new(all_search_paths)
+            .filter_map(|desktop_file_path| {
+                Self::read_desktop_entry_matching(&desktop_file_path.as_path(), content_type)
+            })
+            .collect();
+    }
+
+    fn read_desktop_entry_matching(
+        desktop_file_path: &Path,
+        content_type: &str,
+    ) -> Option<DesktopEntryHolder> {
+        return fs::read_to_string(&desktop_file_path)
+            .ok()
+            .and_then(|file_content| {
+                DesktopEntry::decode(&desktop_file_path, &file_content)
+                    .ok()
+                    .and_then(|entry| {
+                        let contains_mime_type = entry
+                            .mime_type()
+                            .filter(|mime_type_str| {
                                 // e.g "text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;"
                                 let mime_types: Vec<&str> = mime_type_str.split(";").collect();
-                                if mime_types.contains(&content_type) {
-                                    let desktop_entry_holder_maybe =
-                                        Self::freedesktop_desktop_entry_to_desktop_entry_holder(
-                                            &entry,
-                                        );
-                                    desktop_entry_holder_maybe
-                                }
-                            }
-                        }
-                    }
-                    None
-                })
-                .collect();
+                                mime_types.contains(&content_type)
+                            })
+                            .is_some();
 
-        return entry_holders;
+                        if contains_mime_type {
+                            Self::freedesktop_desktop_entry_to_desktop_entry_holder(&entry)
+                        } else {
+                            None
+                        }
+                    })
+            });
     }
 
     fn freedesktop_desktop_entry_to_desktop_entry_holder(
@@ -142,58 +143,6 @@ impl OsHelper {
             display_name: display_name,
             icon: icon_maybe,
             exec: exec.to_string(),
-        });
-    }
-
-    fn glib_find_all_desktop_entries(content_type: &str) -> Vec<DesktopEntryHolder> {
-        let glib_app_infos = AppInfo::all_for_type(content_type);
-
-        /*let app_ids: Vec<String> = glib_app_infos.iter()
-        .filter_map(|app_info| app_info.id())
-        .map(|id_gstring| id_gstring.as_str().to_string())
-        .collect();*/
-
-        let desktop_entry_holders: Vec<DesktopEntryHolder> = glib_app_infos
-            .iter()
-            .map(|glib_app_info| Self::glib_app_info_to_desktop_entry_holder(glib_app_info))
-            .collect();
-
-        return desktop_entry_holders;
-    }
-
-    fn glib_app_info_to_desktop_entry_holder(app_info: &AppInfo) -> Option<DesktopEntryHolder> {
-        let option = app_info.commandline();
-        // uses %u or %U, see https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html
-        // need to use command(), because executable() is not fine, as snap apps just have "env" there
-        let command_with_field_codes = option.unwrap();
-        let command_str = command_with_field_codes.to_str().unwrap();
-
-        let name = app_info.name().to_string();
-        let id_maybe = app_info.id();
-        if id_maybe.is_none() {
-            warn!("no id found for {}", name);
-            return None;
-        }
-
-        let id_gstring = id_maybe.unwrap();
-        let id = id_gstring.as_str().to_string();
-        // "google-chrome-beta.desktop"
-        // "software.Browsers.desktop"
-
-        let icon_maybe = app_info
-            .icon()
-            .and_then(|gio_icon| gio_icon_to_string(&gio_icon));
-
-        let string1 = app_info.display_name();
-        let display_name = string1.as_str();
-        //let _string = app_info.to_string();
-        //println!("app_info: {}", id);
-
-        return Some(DesktopEntryHolder {
-            app_id: id,
-            display_name: display_name.to_string(),
-            icon: icon_maybe,
-            exec: command_str.to_string(),
         });
     }
 
@@ -272,8 +221,7 @@ impl OsHelper {
 
         let app_config_dir_abs = supported_app.get_app_config_dir_abs(is_snap, false);
 
-        let profiles =
-            supported_app.find_profiles(executable_path_best_guess.clone(), app_config_dir_abs);
+        let profiles = supported_app.find_profiles(executable_path_best_guess, app_config_dir_abs);
 
         let browser = InstalledBrowser {
             command: command_parts.clone(),
@@ -287,20 +235,6 @@ impl OsHelper {
         };
         return Some(browser);
     }
-}
-
-fn gio_icon_to_string(icon: &impl IsA<gio::Icon>) -> Option<String> {
-    // icon.to_string() returns either file path or icon name in theme
-    // https://lazka.github.io/pgi-docs/Gio-2.0/interfaces/Icon.html#Gio.Icon.to_string
-    let icon_gstr_maybe = IconExt::to_string(&icon);
-    if icon_gstr_maybe.is_none() {
-        warn!("Could not get filename string representation from icon",);
-        return None;
-    }
-    let icon_gstr = icon_gstr_maybe.unwrap();
-
-    let icon_str = icon_gstr.to_string();
-    return Some(icon_str);
 }
 
 fn create_icon_for_app(icon_str: &str, to_icon_path: &str) {

--- a/src/linux/linux_utils.rs
+++ b/src/linux/linux_utils.rs
@@ -90,7 +90,11 @@ impl OsHelper {
         // collect all .desktop file paths and map them by file name to remove duplicate files,
         // even if they exist in different directories
         let mut desktop_file_paths_by_filename: BTreeMap<_, _> = Iter::new(all_search_paths)
-            .map(|file_path| (file_path.file_name(), file_path))
+            .map(|file_path| {
+                let option1 = file_path.file_name();
+                let option = option1.map(|a| a.to_owned());
+                (option, file_path)
+            })
             .collect();
 
         let cleaned_desktop_file_paths = desktop_file_paths_by_filename.into_values().collect();

--- a/src/linux/linux_utils.rs
+++ b/src/linux/linux_utils.rs
@@ -153,7 +153,7 @@ impl OsHelper {
         restricted_domains: Vec<String>,
     ) -> Option<InstalledBrowser> {
         let id = desktop_entry_holder.app_id.as_str();
-        if id == "software.Browsers.desktop" {
+        if id == "software.Browsers" {
             // this is us, skip
             return None;
         }

--- a/src/windows/windows_utils.rs
+++ b/src/windows/windows_utils.rs
@@ -120,9 +120,14 @@ impl OsHelper {
         scheme: &str,
         root: RegKey,
     ) -> Vec<AppInfoHolder> {
-        let start_menu_internet = root
-            .open_subkey("SOFTWARE\\Clients\\StartMenuInternet")
-            .unwrap();
+        let start_menu_internet_result = root
+            .open_subkey("SOFTWARE\\Clients\\StartMenuInternet");
+
+        if start_menu_internet_result.is_err() {
+            return vec![];
+        }
+
+        let start_menu_internet = start_menu_internet_result.unwrap();
         let bundle_ids = start_menu_internet.enum_keys();
 
         let apps: Vec<AppInfoHolder> = bundle_ids


### PR DESCRIPTION
Replace searching for desktop entries from `glib` to https://github.com/pop-os/freedesktop-desktop-entry
Replacing searching for icons from `gtk` to https://github.com/oknozor/freedesktop-icons

This makes it possible to launch Browsers with `--no-gui` in headless environments for CI testing.