### PR TITLE
linux: add floorp browser

### DIFF
--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -298,6 +298,12 @@ kind = "FIREFOX"
 os = "MAC"
 
 [[apps]]
+id = "floorp"
+config_dir_relative = ".floorp"
+kind = "FIREFOX"
+os = "LINUX"
+
+[[apps]]
 id = "org.torproject.torbrowser"
 config_dir_relative = "TorBrowser-Data/Browser"
 kind = "FIREFOX"


### PR DESCRIPTION
Add the linux variant of the [Floorp](https://github.com/Floorp-Projects/Floorp/) browser (Firefox based)