### PR TITLE
Unwrap URLs

### DIFF
--- a/src/gui/settings_window/general_view.rs
+++ b/src/gui/settings_window/general_view.rs
@@ -5,7 +5,10 @@ use druid::{LensExt, Widget, WidgetExt};
 
 use crate::gui::settings_window::rules_view;
 use crate::gui::shared;
-use crate::gui::ui::{UISettings, UIState, UIVisualSettings, SAVE_UI_SETTINGS};
+use crate::gui::ui::{
+    UIBehavioralSettings, UISettings, UIState, UIVisualSettings, SAVE_BEHAVIORAL_SETTINGS,
+    SAVE_UI_SETTINGS,
+};
 use crate::utils::ConfiguredTheme;
 
 pub(crate) fn general_content() -> impl Widget<UIState> {
@@ -92,6 +95,24 @@ pub(crate) fn general_content() -> impl Widget<UIState> {
 
         col = col.with_child(quit_on_lost_focus_row).with_default_spacer()
     }
+
+    let unwrap_urls_switch = ControllerHost::new(
+        Switch::new(),
+        rules_view::SubmitCommandOnDataChange {
+            command: SAVE_BEHAVIORAL_SETTINGS.with(()),
+        },
+    )
+    .lens(
+        UIState::ui_settings
+            .then(UISettings::behavioral_settings)
+            .then(UIBehavioralSettings::unwrap_urls),
+    );
+
+    let unwrap_urls_row = Flex::row()
+        .with_child(Label::new("Unwrap URLs").with_text_size(TEXT_SIZE))
+        .with_flex_spacer(1.0)
+        .with_child(unwrap_urls_switch);
+    col = col.with_child(unwrap_urls_row).with_default_spacer();
 
     let tooltip = Label::new(
         "To hide and move applications/profiles, close settings and just right-click on the application in the main dialog"

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -628,10 +628,16 @@ impl AppDelegate<UIState> for UIDelegate {
         } else if cmd.is(URL_OPENED) {
             let url_open_info = cmd.get_unchecked(URL_OPENED);
 
+            let settings = &data.ui_settings.behavioral_settings;
+            let behavioral_config = BehavioralConfig {
+                unwrap_urls: settings.unwrap_urls,
+            };
+
             self.main_sender
                 .send(MessageToMain::UrlPassedToMain(
                     url_open_info.source_bundle_id.clone(),
                     url_open_info.url.clone(),
+                    behavioral_config,
                 ))
                 .ok();
             Handled::Yes

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -375,7 +375,11 @@ impl UIBrowser {
 
 impl UIState {}
 
+// "url_opened" is automatically triggered in macOS
 pub const URL_OPENED: Selector<druid::UrlOpenInfo> = Selector::new("url_opened");
+
+// fixed_url_opened is always triggered by Browsers
+pub const FIXED_URL_OPENED: Selector<druid::UrlOpenInfo> = Selector::new("fixed_url_opened");
 pub const APP_LOST_FOCUS: Selector<druid::ApplicationLostFocus> = Selector::new("app_lost_focus");
 
 pub const EXIT_APP: Selector<String> = Selector::new("browsers.exit_app");
@@ -600,6 +604,16 @@ impl AppDelegate<UIState> for UIDelegate {
             Handled::Yes
         } else if cmd.is(URL_OPENED) {
             let url_open_info = cmd.get_unchecked(URL_OPENED);
+
+            self.main_sender
+                .send(MessageToMain::UrlPassedToMain(
+                    url_open_info.source_bundle_id.clone(),
+                    url_open_info.url.clone(),
+                ))
+                .ok();
+            Handled::Yes
+        } else if cmd.is(FIXED_URL_OPENED) {
+            let url_open_info = cmd.get_unchecked(FIXED_URL_OPENED);
             data.url = url_open_info.url.clone();
 
             let filtered_browsers = get_filtered_browsers(&data.url, &data.browsers);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,7 @@ fn get_opening_rules(config: &Config) -> (Vec<OpeningRule>, Option<ProfileAndOpt
 
 #[instrument(skip_all)]
 fn generate_all_browser_profiles(
+    config: &Config,
     app_finder: &OSAppFinder,
     force_reload: bool,
 ) -> (
@@ -464,7 +465,6 @@ fn generate_all_browser_profiles(
     Vec<CommonBrowserProfile>,
 ) {
     let installed_browsers = app_finder.get_installed_browsers_cached(force_reload);
-    let config = app_finder.get_config();
     let hidden_apps = config.get_hidden_apps();
     let hidden_profiles = config.get_hidden_profiles();
 
@@ -654,12 +654,14 @@ pub fn basically_main(
     let is_default = utils::is_default_web_browser();
     let show_set_as_default = !is_default;
 
+    let config = app_finder.get_config();
+
     let (
         mut opening_rules,
         mut default_profile,
         mut visible_browser_profiles,
         mut hidden_browser_profiles,
-    ) = generate_all_browser_profiles(&app_finder, force_reload);
+    ) = generate_all_browser_profiles(&config, &app_finder, force_reload);
 
     // TODO: url should not be considered here in case of macos
     //       and only the one in LinkOpenedFromBundle should be considered
@@ -717,8 +719,11 @@ pub fn basically_main(
             match message {
                 MessageToMain::Refresh => {
                     info!("refresh called");
+
+                    let config = app_finder.get_config();
+
                     let (_, _, visible_browser_profiles, _) =
-                        generate_all_browser_profiles(&app_finder, true);
+                        generate_all_browser_profiles(&config, &app_finder, true);
 
                     let ui_browsers = UI::real_to_ui_browsers(&visible_browser_profiles);
                     ui_event_sink

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -47,6 +47,13 @@ pub struct Config {
     default_profile: Option<ProfileAndOptions>,
     rules: Vec<ConfigRule>,
     ui: UIConfig,
+    behavior: BehavioralConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct BehavioralConfig {
+    pub unwrap_urls: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -61,13 +68,6 @@ pub struct UIConfig {
     pub theme: ConfiguredTheme,
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Data, PartialEq)]
-pub enum ConfiguredTheme {
-    Auto,
-    Light,
-    Dark,
-}
-
 impl Default for UIConfig {
     fn default() -> Self {
         UIConfig {
@@ -76,6 +76,13 @@ impl Default for UIConfig {
             theme: ConfiguredTheme::Auto,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Data, PartialEq)]
+pub enum ConfiguredTheme {
+    Auto,
+    Light,
+    Dark,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
@@ -179,6 +186,14 @@ impl Config {
 
     pub fn set_ui_config(&mut self, ui_config: UIConfig) {
         self.ui = ui_config
+    }
+
+    pub fn get_behavior(&self) -> &BehavioralConfig {
+        return &self.behavior;
+    }
+
+    pub fn set_behavior(&mut self, behavior: BehavioralConfig) {
+        self.behavior = behavior;
     }
 }
 


### PR DESCRIPTION
Unwrap URLs.

Currently supporting only `https://<datacenter>.safelinks.protection.outlook.com` from https://learn.microsoft.com/en-us/defender-office-365/safe-links-about#safe-links-settings-for-email-messages

By default unwrapping is disabled and it can be enabled in configuration UI.

Fixes #202