### PR TITLE
Allow setting Browsers as default http/https handler in Linux

### DIFF
--- a/extra/linux/dist/install.sh
+++ b/extra/linux/dist/install.sh
@@ -211,7 +211,7 @@ if [[ $* != *--skip-desktop-database* ]]; then
   update-desktop-database "$TARGET_DESKTOP_DIR_PATH"
 
   # Sets Browsers as default application for https and http mimetypes
-  xdg-mime default "software.Browsers.desktop" https http || echo "Could not make Browsers as default web link opener"
+  xdg-mime default "software.Browsers.desktop" x-scheme-handler/https x-scheme-handler/http || echo "Could not make Browsers as default web link opener"
 fi
 
 echo "Browsers has been installed. Enjoy!"

--- a/extra/linux/dist/install.sh
+++ b/extra/linux/dist/install.sh
@@ -209,6 +209,9 @@ if [[ $* != *--skip-desktop-database* ]]; then
   # The update-desktop-database program is a tool to build a cache database of the MIME types handled by desktop files.
   # Refresh desktop database
   update-desktop-database "$TARGET_DESKTOP_DIR_PATH"
+
+  # Sets Browsers as default application for https and http mimetypes
+  xdg-mime default "software.Browsers.desktop" https http || echo "Could not make Browsers as default web link opener"
 fi
 
 echo "Browsers has been installed. Enjoy!"

--- a/src/linux/linux_utils.rs
+++ b/src/linux/linux_utils.rs
@@ -442,7 +442,8 @@ pub fn set_default_web_browser() -> bool {
     let result = Command::new("xdg-mime")
         .arg("default")
         .arg(desktop_file_name.as_str())
-        .arg("https http")
+        .arg("x-scheme-handler/https")
+        .arg("x-scheme-handler/http")
         .status();
 
     if result.is_err() {
@@ -455,8 +456,8 @@ pub fn set_default_web_browser() -> bool {
 pub fn is_default_web_browser() -> bool {
     let desktop_file_name = format!("{}.desktop", XDG_NAME);
 
-    let https_default_app = query_default_app("https").unwrap_or("".to_string());
-    let http_default_app = query_default_app("http").unwrap_or("".to_string());
+    let https_default_app = query_default_app("x-scheme-handler/https").unwrap_or("".to_string());
+    let http_default_app = query_default_app("x-scheme-handler/http").unwrap_or("".to_string());
 
     return https_default_app == desktop_file_name && http_default_app == desktop_file_name;
 }
@@ -477,6 +478,7 @@ fn query_default_app(scheme: &str) -> Option<String> {
     let output = result.unwrap();
 
     // extract the raw bytes that we captured and interpret them as a string
-    let default_app = String::from_utf8(output.stdout).unwrap();
+    let default_app = String::from_utf8(output.stdout).unwrap().trim().to_string();
+    info!("Default for {scheme} is '{default_app}'");
     return Some(default_app);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,14 +18,24 @@ use crate::macos::macos_utils;
 use crate::windows::windows_utils;
 use crate::{paths, InstalledBrowser, SupportedAppRepository};
 
+#[cfg(target_os = "linux")]
+pub fn is_default_web_browser() -> bool {
+    return linux_utils::is_default_web_browser();
+}
+
 #[cfg(target_os = "macos")]
 pub fn is_default_web_browser() -> bool {
     return macos_utils::is_default_web_browser();
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
 pub fn is_default_web_browser() -> bool {
     return true;
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_as_default_web_browser() -> bool {
+    return linux_utils::set_default_web_browser();
 }
 
 #[cfg(target_os = "macos")]
@@ -33,7 +43,7 @@ pub fn set_as_default_web_browser() -> bool {
     return macos_utils::set_default_web_browser();
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
 pub fn set_as_default_web_browser() -> bool {
     return true;
 }


### PR DESCRIPTION
Allow setting Browsers as default http/https handler in Linux without having to manually going to desktop settings.