### PR TITLE
refactor: split lib.rs entrypoint into two methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,16 +111,31 @@ jobs:
           command_output="$(./browsers --no-gui https://browsers.software)"
           echo "$command_output"
           
+          failed=false
+          
           if echo "$command_output" | grep -q 'Firefox Web Browser'; then
             echo "matched Firefox Web Browser"
+          else
+            echo "did NOT match Firefox Web Browser"
+            failed=true
           fi
           
           if echo "$command_output" | grep -q 'Google Chrome'; then
             echo "matched Google Chrome"
+          else
+            echo "did NOT match Google Chrome"
+            failed=true
           fi
           
           if echo "$command_output" | grep -q 'Microsoft Edge'; then
             echo "matched Microsoft Edge"
+          else
+            echo "did NOT match Google Chrome"
+            failed=true
+          fi
+          
+          if [ "$failed" = true ]; then
+            exit 1
           fi
         shell: bash
       - name: Upload release artifact
@@ -224,16 +239,30 @@ jobs:
           command_output=`cat ./output_file`
           echo "$command_output"
           
+          failed=false
           if echo "$command_output" | grep -q 'Safari'; then
             echo "matched Safari"
+          else
+            echo "did NOT match Safari"
+            failed=true
           fi
           
           if echo "$command_output" | grep -q 'Chrome'; then
             echo "matched Chrome"
+          else
+            echo "did NOT match Chrome"
+            failed=true
           fi
           
           if echo "$command_output" | grep -q 'Google Chrome for Testing'; then
             echo "matched Google Chrome for Testing"
+          else
+            echo "did NOT match Google Chrome for Testing"
+            failed=true
+          fi
+          
+          if [ "$failed" = true ]; then
+            exit 1
           fi
         # special shell script to make tty working
         shell: 'script -q /dev/null bash -e {0}'
@@ -318,20 +347,37 @@ jobs:
           command_output="$(./browsers.exe --no-gui https://browsers.software)"
           echo "$command_output"
           
+          failed=false
           if echo "$command_output" | grep -q 'Mozilla Firefox'; then
             echo "matched Mozilla Firefox"
+          else
+            echo "did NOT match Mozilla Firefox"
+            failed=true
           fi
           
           if echo "$command_output" | grep -q 'Google Chrome'; then
             echo "matched Google Chrome"
+          else
+            echo "did NOT match Google Chrome"
+            failed=true
           fi
           
           if echo "$command_output" | grep -q 'Internet Explorer'; then
             echo "matched Internet Explorer"
+          else
+            echo "did NOT match Internet Explorer"
+            failed=true
           fi
           
-          if echo "$command_output" | grep -q ' Microsoft Edge (Profile 1)'; then
+          if echo "$command_output" | grep -q 'Microsoft Edge (Profile 1)'; then
             echo "matched Microsoft Edge (Profile 1)"
+          else
+            echo "did NOT match Microsoft Edge (Profile 1)"
+            failed=true
+          fi
+
+          if [ "$failed" = true ]; then
+            exit 1
           fi
         shell: bash
       - name: Upload release artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,6 @@ dependencies = [
  "freedesktop-desktop-entry",
  "freedesktop-icons",
  "globset",
- "interprocess",
  "lazy_static",
  "libc",
  "naive-cityhash",
@@ -376,7 +375,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
- "single-instance",
  "static_vcruntime",
  "toml 0.8.20",
  "tracing",
@@ -812,12 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
-
-[[package]]
 name = "druid"
 version = "0.8.3"
 source = "git+https://github.com/browsers-software/druid.git?branch=browsers#d03ea912723e77394d30807983cdfb1d07cebd91"
@@ -989,7 +981,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -1684,19 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
-dependencies = [
- "doctest-file",
- "libc",
- "recvmsg",
- "widestring 1.2.0",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "intl-memoizer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,15 +1828,6 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1895,19 +1865,6 @@ checksum = "fce7b49e1e6d8aa67232ef1c4c936c0af58756eb2db6f65c40bacb39035e7f42"
 
 [[package]]
 name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -1916,7 +1873,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -2376,12 +2333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,19 +2555,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "single-instance"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4637485391f8545c9d3dbf60f9d9aab27a90c789a700999677583bcb17c8795d"
-dependencies = [
- "libc",
- "nix 0.23.2",
- "thiserror 1.0.69",
- "widestring 0.4.3",
- "winapi",
-]
 
 [[package]]
 name = "slab"
@@ -2971,7 +2909,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "winapi",
 ]
@@ -3224,18 +3162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
-
-[[package]]
-name = "widestring"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,15 +3190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3568,7 +3485,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.29.0",
+ "nix",
  "ordered-stream",
  "serde",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,7 @@ naive-cityhash = "0.2.0"
 # To create lazy static variables
 lazy_static = "1.5.0"
 
-# When running a new instance of Browsers, new instances will check if existing instance is already running
-single-instance = "0.3.3"
-
-# When running a new instance of Browsers, new instances will send arguments
-# to existing process via this library (and then close itself)
-interprocess = "2.2.3"
+# Dark-light system theme detection
 dark-light = "2.0.0"
 
 # macOS Core Foundation bindings
@@ -72,6 +67,9 @@ libc = "0.2.154"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 xdg-mime = "^0.4.0"
+
+# eagerly init gtk (should be same version of gtk as druid is using)
+#gtk = { version = "0.16.2" }
 
 # to find application .desktop files
 freedesktop-desktop-entry = "0.7.0"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -186,7 +186,7 @@ impl Config {
         return &self.default_profile;
     }
 
-    pub fn set_default_profile(&mut self, default_profile: Option<ProfileAndOptions>) {
+    pub fn set_default_profile(&mut self, default_profile: &Option<ProfileAndOptions>) {
         self.default_profile = default_profile.clone()
     }
 
@@ -290,7 +290,7 @@ impl OSAppFinder {
         serde_json::to_writer_pretty(buffer, config).unwrap();
     }
 
-    pub(crate) fn get_config(&self) -> Config {
+    pub fn load_config(&self) -> Config {
         let config_root_dir = paths::get_config_root_dir();
         fs::create_dir_all(config_root_dir.as_path()).unwrap();
         let config_json_path = paths::get_config_json_path();


### PR DESCRIPTION
Refactor: split `basically_main()` in `lib.rs` to `handle_messages_to_main()` and `prepare_ui()`