### PR TITLE
feat: add helium browser to application-repository

### DIFF
--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -276,6 +276,12 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
+id = "net.imput.helium"
+config_dir_relative = "net.imput.helium"
+kind = "CHROMIUM"
+os = "MAC"
+
+[[apps]]
 id = "org.mozilla.firefox"
 config_dir_relative = "Firefox"
 kind = "FIREFOX"


### PR DESCRIPTION
I added [Helium Browser](https://helium.computer/) to the list of applications.

Tested on my Mac.