### PR TITLE
feat(repository): add "org.nixos.firefox"

### DIFF
--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -288,6 +288,12 @@ kind = "FIREFOX"
 os = "MAC"
 
 [[apps]]
+id = "org.nixos.firefox"
+config_dir_relative = "Firefox"
+kind = "FIREFOX"
+os = "MAC"
+
+[[apps]]
 id = "firefox"
 config_dir_relative = ".mozilla/firefox"
 snap_dir = "firefox"


### PR DESCRIPTION
`nix-darwin` Firefox seems to register an app "org.nixos.firefox" through https://github.com/NixOS/nixpkgs/blob/c49b175d541c54967dde3265eceda219e7ba6037/pkgs/build-support/make-darwin-bundle/write-darwin-bundle.nix#L13

Browsers started picking up profiles and containers correctly after adding entry manually to `/Applications/Browsers.app/Contents/Resources/repository/application-repository.toml`