### PR TITLE
feat(repository): add helium browser linux and windows entries

### DIFF
--- a/resources/repository/application-repository.toml
+++ b/resources/repository/application-repository.toml
@@ -282,6 +282,18 @@ kind = "CHROMIUM"
 os = "MAC"
 
 [[apps]]
+id = "helium"
+config_dir_relative = "net.imput.helium"
+kind = "CHROMIUM"
+os = "LINUX"
+
+[[apps]]
+id = "Helium"
+config_dir_relative = "imput/Helium/User Data"
+kind = "CHROMIUM"
+os = "WINDOWS"
+
+[[apps]]
 id = "org.mozilla.firefox"
 config_dir_relative = "Firefox"
 kind = "FIREFOX"


### PR DESCRIPTION
Helium was added in https://github.com/Browsers-software/browsers/pull/357, but only for macOS. I added entries for Linux and Windows as well.