### PR TITLE
fix panic when CFBundleName is missing from Info.plist

### DIFF
--- a/src/macos/macos_native.rs
+++ b/src/macos/macos_native.rs
@@ -93,9 +93,16 @@ pub fn macos_get_directory(directory: NSSearchPathDirectory) -> PathBuf {
 
 pub(crate) fn get_app_name(bundle_path: &NSString) -> String {
     let bundle = get_bundle(bundle_path);
+
     //bundleWithURL
-    let bundle_name = bundle.name().unwrap();
-    bundle_name.to_string()
+    bundle
+        .name() // Info.plist -> CFBundleName (optional)
+        .unwrap_or_else(|| {
+            bundle_path
+                .lastPathComponent()
+                .stringByDeletingPathExtension() // SomeBrowser.app -> SomeBrowser
+        })
+        .to_string()
 }
 
 pub(crate) fn get_app_executable_path(bundle_path: &NSString) -> String {


### PR DESCRIPTION
Ladybird browser currently does not have `CFBundleName` in `Info.plist`.
Don't panic, but use the app directory name (without the .app extension).