### PR TITLE
fix: resign focus when hover is lost on a browser list item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [unreleased]
+
+### Fixed
+
+- Fix unfocusing focused item when moving mouse away. Thanks to @devnullvoid for contribution #341
 
 ## [0.7.4] - 2026-08-09
 
@@ -22,7 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Windows: Don't show same browser twice if it has an entry for user and system at the same time. Thanks to @kfatehi for contribution #337
+- Windows: Don't show same browser twice if it has an entry for user and system at the same time. Thanks to @kfatehi for
+  contribution #337
 
 ## [0.7.2] - 2025-10-04
 

--- a/src/gui/focus_widget.rs
+++ b/src/gui/focus_widget.rs
@@ -10,11 +10,14 @@ pub trait FocusData {
 
 pub const FOCUS_WIDGET_SET_FOCUS_ON_HOVER: Selector<WidgetId> =
     Selector::new("focus_widget.set_focus");
+pub const FOCUS_WIDGET_RESIGN_FOCUS: Selector<WidgetId> =
+    Selector::new("focus_widget.resign_focus");
 
 pub struct FocusWidget<S: druid::Data + FocusData, W> {
     inner: W,
     paint_fn_on_focus: fn(ctx: &mut PaintCtx, data: &S, env: &Env),
     lifecycle_fn: fn(ctx: &mut LifeCycleCtx, data: &S, env: &Env),
+    hover_lost_fn: Option<fn(ctx: &mut LifeCycleCtx, data: &S, env: &Env)>,
 }
 
 impl<S: druid::Data + FocusData, W> FocusWidget<S, W> {}
@@ -29,7 +32,13 @@ impl<S: druid::Data + FocusData, W> FocusWidget<S, W> {
             inner,
             paint_fn_on_focus,
             lifecycle_fn,
+            hover_lost_fn: None,
         }
+    }
+
+    pub fn on_hover_lost(mut self, f: fn(ctx: &mut LifeCycleCtx, data: &S, env: &Env)) -> Self {
+        self.hover_lost_fn = Some(f);
+        self
     }
 }
 
@@ -44,6 +53,14 @@ impl<S: druid::Data + FocusData, W: Widget<S>> Widget<S> for FocusWidget<S, W> {
                 //    widget_id
                 //);
                 ctx.request_focus();
+                ctx.request_paint();
+                ctx.set_handled();
+                ctx.request_update();
+            }
+            Event::Command(cmd) if cmd.is(FOCUS_WIDGET_RESIGN_FOCUS) => {
+                if ctx.has_focus() {
+                    ctx.resign_focus();
+                }
                 ctx.request_paint();
                 ctx.set_handled();
                 ctx.request_update();
@@ -125,6 +142,18 @@ impl<S: druid::Data + FocusData, W: Widget<S>> Widget<S> for FocusWidget<S, W> {
                     );
                     ctx.submit_command(cmd);
                     //ctx.request_paint();
+                } else if !*to_hot {
+                    if let Some(f) = self.hover_lost_fn {
+                        f(ctx, data, env);
+                    }
+                    if ctx.has_focus() {
+                        let cmd = Command::new(
+                            FOCUS_WIDGET_RESIGN_FOCUS,
+                            ctx.widget_id(),
+                            Target::Widget(ctx.widget_id()),
+                        );
+                        ctx.submit_command(cmd);
+                    }
                 }
             }
             _ => {}

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -476,7 +476,14 @@ fn create_browser(
                     .ok();
             }
         },
-    );
+    )
+    .on_hover_lost(|ctx, _, _| {
+        if ctx.has_focus() {
+            ctx.get_external_handle()
+                .submit_command(SET_FOCUSED_INDEX, None, Target::Global)
+                .ok();
+        }
+    });
 
     let container = Container::new(container);
 


### PR DESCRIPTION
Fixes unfocusing when mouse moves away from highlighted browser.

`FocusWidget` now exposes an `on_hover_lost` hook.
The browser list item uses it to resign focus and clear `SET_FOCUSED_INDEX` when hover ends.

Extracted from https://github.com/Browsers-software/browsers/pull/341

