### PR TITLE
refactor: use theme constants for environment label styling

### DIFF
--- a/src/gui/settings_window/appearance_view.rs
+++ b/src/gui/settings_window/appearance_view.rs
@@ -1,0 +1,230 @@
+use druid::widget::{
+    ControllerHost, CrossAxisAlignment, Flex, Label, RadioGroup, TextBox,
+};
+use druid::{Color, LensExt, Widget, WidgetExt};
+
+use crate::gui::settings_window::rules_view;
+use crate::gui::ui::{
+    UISettings, UIState, UIVisualSettings, SAVE_UI_SETTINGS,
+};
+use crate::utils::{CustomTheme, ThemeMode};
+
+pub(crate) fn appearance_content() -> impl Widget<UIState> {
+    const TEXT_SIZE: f64 = 13.0;
+    let save_command = SAVE_UI_SETTINGS.with(());
+
+    let theme_radio_group = ControllerHost::new(
+        RadioGroup::column(vec![
+            ("Match system", ThemeMode::Auto),
+            ("Light", ThemeMode::Light),
+            ("Dark", ThemeMode::Dark),
+            ("Custom", ThemeMode::Custom),
+        ]),
+        rules_view::SubmitCommandOnDataChange {
+            command: save_command.clone(),
+        },
+    )
+    .lens(
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::theme_mode),
+    );
+
+    let theme_radio_row = Flex::row()
+        .with_child(Label::new("Theme").with_text_size(TEXT_SIZE))
+        .with_flex_spacer(1.0)
+        .with_child(theme_radio_group);
+
+    // Custom theme inputs
+    let window_bg_input = make_color_input("Window Background", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::window_background),
+        save_command.clone());
+
+    let text_color_input = make_color_input("Text Color", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::text_color),
+        save_command.clone());
+        
+    let active_tab_bg_input = make_color_input("Active Tab Background", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::active_tab_background),
+        save_command.clone());
+
+    let active_tab_text_input = make_color_input("Active Tab Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::active_tab_text),
+        save_command.clone());
+
+    let inactive_tab_text_input = make_color_input("Inactive Tab Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::inactive_tab_text),
+        save_command.clone());
+
+    let hover_background_input = make_color_input("Hover/Selected Background", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hover_background),
+        save_command.clone());
+
+    let hover_text_input = make_color_input("Hover/Selected Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hover_text),
+        save_command.clone());
+
+    let secondary_text_input = make_color_input("Secondary Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::secondary_text),
+        save_command.clone());
+
+    let hover_secondary_text_input = make_color_input("Hover/Selected Secondary Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hover_secondary_text),
+        save_command.clone());
+
+    let hotkey_background_input = make_color_input("Hotkey Background", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hotkey_background),
+        save_command.clone());
+
+    let hotkey_text_input = make_color_input("Hotkey Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hotkey_text),
+        save_command.clone());
+
+    let hover_hotkey_background_input = make_color_input("Hover Hotkey Background", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hover_hotkey_background),
+        save_command.clone());
+
+    let hover_hotkey_text_input = make_color_input("Hover Hotkey Text", 
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::hover_hotkey_text),
+        save_command.clone());
+
+    let primary_font_size_input = make_input("Primary Font Size",
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::primary_font_size),
+        save_command.clone());
+
+    let primary_font_family_input = make_input("Primary Font Family",
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::primary_font_family),
+        save_command.clone());
+
+    let secondary_font_size_input = make_input("Secondary Font Size",
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::secondary_font_size),
+        save_command.clone());
+
+    let secondary_font_family_input = make_input("Secondary Font Family",
+        UIState::ui_settings
+            .then(UISettings::visual_settings)
+            .then(UIVisualSettings::custom_theme)
+            .then(CustomTheme::secondary_font_family),
+        save_command.clone());
+
+    Flex::column()
+        .cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(theme_radio_row)
+        .with_default_spacer()
+        .with_child(Label::new("Custom Theme Colors (Hex)").with_text_size(TEXT_SIZE))
+        .with_spacer(5.0)
+        .with_child(window_bg_input)
+        .with_spacer(5.0)
+        .with_child(text_color_input)
+        .with_spacer(5.0)
+        .with_child(active_tab_bg_input)
+        .with_spacer(5.0)
+        .with_child(active_tab_text_input)
+        .with_spacer(5.0)
+        .with_child(inactive_tab_text_input)
+        .with_spacer(5.0)
+        .with_child(hover_background_input)
+        .with_spacer(5.0)
+        .with_child(hover_text_input)
+        .with_spacer(5.0)
+        .with_child(secondary_text_input)
+        .with_spacer(5.0)
+        .with_child(hover_secondary_text_input)
+        .with_spacer(5.0)
+        .with_child(hotkey_background_input)
+        .with_spacer(5.0)
+        .with_child(hotkey_text_input)
+        .with_spacer(5.0)
+        .with_child(hover_hotkey_background_input)
+        .with_spacer(5.0)
+        .with_child(hover_hotkey_text_input)
+        .with_spacer(10.0)
+        .with_child(Label::new("Fonts").with_text_size(14.0).with_text_color(Color::WHITE))
+        .with_spacer(5.0)
+        .with_child(primary_font_size_input)
+        .with_spacer(5.0)
+        .with_child(primary_font_family_input)
+        .with_spacer(5.0)
+        .with_child(secondary_font_size_input)
+        .with_spacer(5.0)
+        .with_child(secondary_font_family_input)
+}
+
+fn make_input(label: &str, lens: impl druid::Lens<UIState, String> + 'static, save_command: druid::Command) -> impl Widget<UIState> {
+    Flex::column()
+        .cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(Label::new(label).with_text_size(12.0))
+        .with_spacer(2.0)
+        .with_child(
+            druid::widget::TextBox::new()
+                .with_placeholder(label)
+                .lens(lens)
+                .controller(rules_view::SubmitCommandOnDataChange {
+                    command: save_command,
+                })
+                .expand_width()
+        )
+}
+
+fn make_color_input(label: &str, lens: impl druid::Lens<UIState, String> + 'static, save_command: druid::Command) -> impl Widget<UIState> {
+    let input = ControllerHost::new(
+        TextBox::new(),
+        rules_view::SubmitCommandOnDataChange {
+            command: save_command,
+        },
+    )
+    .lens(lens);
+
+    Flex::row()
+        .with_child(Label::new(label).with_text_size(13.0))
+        .with_flex_spacer(1.0)
+        .with_child(input.fix_width(100.0))
+}

--- a/src/gui/settings_window/general_view.rs
+++ b/src/gui/settings_window/general_view.rs
@@ -1,5 +1,5 @@
 use druid::widget::{
-    Button, ControllerHost, CrossAxisAlignment, Flex, Label, LineBreaking, RadioGroup, Switch,
+    Button, ControllerHost, CrossAxisAlignment, Flex, Label, LineBreaking, Switch,
 };
 use druid::{LensExt, Widget, WidgetExt};
 
@@ -9,33 +9,11 @@ use crate::gui::ui::{
     UIBehavioralSettings, UISettings, UIState, UIVisualSettings, SAVE_BEHAVIORAL_SETTINGS,
     SAVE_UI_SETTINGS,
 };
-use crate::utils::ConfiguredTheme;
 
 pub(crate) fn general_content() -> impl Widget<UIState> {
     const TEXT_SIZE: f64 = 13.0;
 
     let save_command = SAVE_UI_SETTINGS.with(());
-
-    let theme_radio_group = ControllerHost::new(
-        RadioGroup::column(vec![
-            ("Match system", ConfiguredTheme::Auto),
-            ("Light", ConfiguredTheme::Light),
-            ("Dark", ConfiguredTheme::Dark),
-        ]),
-        rules_view::SubmitCommandOnDataChange {
-            command: save_command.clone(),
-        },
-    )
-    .lens(
-        UIState::ui_settings
-            .then(UISettings::visual_settings)
-            .then(UIVisualSettings::theme),
-    );
-
-    let theme_radio_row = Flex::row()
-        .with_child(Label::new("Theme").with_text_size(TEXT_SIZE))
-        .with_flex_spacer(1.0)
-        .with_child(theme_radio_group);
 
     let hotkeys_switch = ControllerHost::new(
         Switch::new(),
@@ -66,8 +44,6 @@ pub(crate) fn general_content() -> impl Widget<UIState> {
 
     let mut col = Flex::column()
         .cross_axis_alignment(CrossAxisAlignment::Start)
-        .with_child(theme_radio_row)
-        .with_default_spacer()
         .with_child(hotkeys_row)
         .with_default_spacer();
 

--- a/src/gui/settings_window/mod.rs
+++ b/src/gui/settings_window/mod.rs
@@ -12,6 +12,7 @@ use crate::gui::ui_theme;
 use crate::gui::ui_theme::{GeneralTheme, SettingsWindowTheme};
 
 mod advanced_view;
+mod appearance_view;
 mod general_view;
 mod rules_view;
 
@@ -102,6 +103,10 @@ fn view_switcher(browsers_arc: Arc<Vec<UIBrowser>>) -> ViewSwitcher<UIState, Set
             SettingsTab::ADVANCED => {
                 settings_view_container("settings-tab-advanced", advanced_view::advanced_content())
             }
+            SettingsTab::APPEARANCE => settings_view_container(
+                "settings-tab-appearance",
+                appearance_view::appearance_content(),
+            ),
         },
     )
 }
@@ -137,6 +142,7 @@ fn sidebar_items() -> impl Widget<UISettings> {
         .cross_axis_alignment(CrossAxisAlignment::Fill)
         .with_child(tab_button("settings-tab-general", SettingsTab::GENERAL))
         .with_child(tab_button("settings-tab-rules", SettingsTab::RULES))
+        .with_child(tab_button("settings-tab-appearance", SettingsTab::APPEARANCE))
         .with_child(tab_button("settings-tab-advanced", SettingsTab::ADVANCED))
         .with_flex_spacer(1.0)
         .fix_width(SIDEBAR_ITEM_WIDTH)

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -21,7 +21,9 @@ use crate::gui::main_window::{
 use crate::gui::ui::SettingsTab::GENERAL;
 use crate::gui::{about_dialog, main_window, settings_window, ui_theme};
 use crate::url_rule::UrlGlobMatcher;
-use crate::utils::{BehavioralConfig, Config, ConfiguredTheme, ProfileAndOptions, UIConfig};
+use crate::utils::{
+    BehavioralConfig, Config, CustomTheme, ProfileAndOptions, ThemeMode, UIConfig,
+};
 use crate::{CommonBrowserProfile, MessageToMain};
 
 pub struct UI {
@@ -71,7 +73,8 @@ impl UI {
         UIVisualSettings {
             show_hotkeys: ui_config.show_hotkeys,
             quit_on_lost_focus: ui_config.quit_on_lost_focus,
-            theme: ui_config.theme,
+            theme_mode: ui_config.theme_mode.clone(),
+            custom_theme: ui_config.custom_theme.clone(),
         }
     }
 
@@ -238,7 +241,8 @@ pub struct UISettings {
 pub struct UIVisualSettings {
     pub show_hotkeys: bool,
     pub quit_on_lost_focus: bool,
-    pub theme: ConfiguredTheme,
+    pub theme_mode: ThemeMode,
+    pub custom_theme: CustomTheme,
 }
 
 #[derive(Clone, Debug, Data, Lens)]
@@ -257,6 +261,7 @@ pub enum SettingsTab {
     GENERAL,
     RULES,
     ADVANCED,
+    APPEARANCE,
 }
 
 impl UISettings {

--- a/src/gui/ui_theme.rs
+++ b/src/gui/ui_theme.rs
@@ -1,14 +1,15 @@
 use crate::gui::ui::UIState;
-use crate::utils::ConfiguredTheme;
+use crate::utils::{CustomTheme, ThemeMode};
 use dark_light::Mode;
 use druid::{Color, Data, Env, FontDescriptor, FontFamily, Key};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Data)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Data)]
 pub enum UITheme {
     Light,
     Dark,
+    Custom(CustomTheme),
 }
 
 pub fn initialize_theme(env: &mut Env, ui_state: &UIState) {
@@ -17,10 +18,13 @@ pub fn initialize_theme(env: &mut Env, ui_state: &UIState) {
 }
 
 fn get_active_ui_theme(ui_state: &UIState) -> UITheme {
-    match ui_state.ui_settings.visual_settings.theme {
-        ConfiguredTheme::Auto => detect_system_theme(),
-        ConfiguredTheme::Light => UITheme::Light,
-        ConfiguredTheme::Dark => UITheme::Dark,
+    match ui_state.ui_settings.visual_settings.theme_mode {
+        ThemeMode::Auto => detect_system_theme(),
+        ThemeMode::Light => UITheme::Light,
+        ThemeMode::Dark => UITheme::Dark,
+        ThemeMode::Custom => {
+            UITheme::Custom(ui_state.ui_settings.visual_settings.custom_theme.clone())
+        }
     }
 }
 
@@ -175,6 +179,7 @@ fn get_theme(ui_theme: UITheme) -> Theme {
     let theme = match ui_theme {
         UITheme::Light => light_theme,
         UITheme::Dark => dark_theme,
+        UITheme::Custom(custom) => custom_theme(&custom, dark_theme),
     };
 
     return theme;
@@ -495,3 +500,106 @@ struct Palette {}
 //.adding(UI_FONT, FontDescriptor::new(FontFamily::SYSTEM_UI).with_size(15.0))
 //.adding(UI_FONT_BOLD, FontDescriptor::new(FontFamily::SYSTEM_UI).with_weight(FontWeight::BOLD).with_size(15.0))
 //.adding(UI_FONT_ITALIC, FontDescriptor::new(FontFamily::SYSTEM_UI).with_style(FontStyle::Italic).with_size(15.0))
+
+fn custom_theme(custom: &CustomTheme, base_theme: Theme) -> Theme {
+    let mut theme = base_theme; // Start with dark theme as base
+
+    if let Ok(color) = parse_color(&custom.window_background) {
+        theme.druid_builtin.window_background_color = color.clone();
+        theme.general.window_background_color = color.clone();
+        theme.main.window_background_color = color.clone();
+    }
+
+    if let Ok(color) = parse_color(&custom.text_color) {
+        theme.druid_builtin.text_color = color.clone();
+        theme.main.browser_label_color = color.clone();
+    }
+
+    if let Ok(color) = parse_color(&custom.active_tab_background) {
+        theme.settings.active_tab_background_color = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.active_tab_text) {
+        theme.settings.active_tab_text_color = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.inactive_tab_text) {
+        theme.settings.inactive_tab_text_color = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.hover_background) {
+        theme.main.item_background_color_hover = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.hover_text) {
+        theme.main.browser_label_color_hover = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.secondary_text) {
+        theme.main.profile_label_color = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.hover_secondary_text) {
+        theme.main.profile_label_color_hover = color;
+    }
+
+    if let Some(size) = parse_font_size(&custom.primary_font_size) {
+        theme.main.browser_label_size = size;
+    }
+
+    if let Some(family) = parse_font_family(&custom.primary_font_family) {
+        theme.main.browser_label_font_family = family;
+    }
+
+    if let Some(size) = parse_font_size(&custom.secondary_font_size) {
+        theme.main.profile_label_size = size;
+    }
+
+    if let Some(family) = parse_font_family(&custom.secondary_font_family) {
+        theme.main.profile_label_font_family = family;
+    }
+
+    if let Ok(color) = parse_color(&custom.hotkey_background) {
+        theme.main.hotkey_background_color = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.hotkey_text) {
+        theme.main.hotkey_text_color = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.hover_hotkey_background) {
+        theme.main.hotkey_background_color_hover = color;
+    }
+
+    if let Ok(color) = parse_color(&custom.hover_hotkey_text) {
+        theme.main.hotkey_text_color_hover = color;
+    }
+
+    theme
+}
+
+fn parse_color(hex: &str) -> Result<Color, ()> {
+    if hex.len() != 7 || !hex.starts_with('#') {
+        return Err(());
+    }
+    let r = u8::from_str_radix(&hex[1..3], 16).map_err(|_| ())?;
+    let g = u8::from_str_radix(&hex[3..5], 16).map_err(|_| ())?;
+    let b = u8::from_str_radix(&hex[5..7], 16).map_err(|_| ())?;
+    Ok(Color::rgb8(r, g, b))
+}
+
+fn parse_font_family(family: &str) -> Option<FontFamily> {
+    let font_family = match family {
+        "default" | "System UI" => FontFamily::SYSTEM_UI,
+        "Serif" => FontFamily::SERIF,
+        "Sans Serif" => FontFamily::SANS_SERIF,
+        "Monospace" => FontFamily::MONOSPACE,
+        name => FontFamily::new_unchecked(name),
+    };
+
+    Some(font_family)
+}
+
+fn parse_font_size(size: &str) -> Option<f64> {
+    size.parse::<f64>().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -936,7 +936,8 @@ pub fn handle_messages_to_main(
                 let ui_config = UIConfig {
                     show_hotkeys: settings.show_hotkeys,
                     quit_on_lost_focus: settings.quit_on_lost_focus,
-                    theme: settings.theme,
+                    theme_mode: settings.theme_mode,
+                    custom_theme: settings.custom_theme,
                 };
 
                 let mut config = app_finder.load_config();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use std::{fs, u32};
 
 use druid::image::imageops::FilterType;
 use druid::image::{ImageFormat, Rgba};
-use druid::{image, Data};
+use druid::{image, Data, Lens};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
@@ -75,7 +75,8 @@ pub struct UIConfig {
     // linux calls this even when just opening a context menu (e.g the 3-dot menu)
     pub quit_on_lost_focus: bool,
 
-    pub theme: ConfiguredTheme,
+    pub theme_mode: ThemeMode,
+    pub custom_theme: CustomTheme,
 }
 
 impl Default for UIConfig {
@@ -83,16 +84,63 @@ impl Default for UIConfig {
         UIConfig {
             show_hotkeys: true,
             quit_on_lost_focus: false,
-            theme: ConfiguredTheme::Auto,
+            theme_mode: ThemeMode::Auto,
+            custom_theme: CustomTheme::default(),
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Data, PartialEq)]
-pub enum ConfiguredTheme {
+#[derive(Serialize, Deserialize, Debug, Clone, Data, PartialEq)]
+pub enum ThemeMode {
     Auto,
     Light,
     Dark,
+    Custom,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Data, Lens, PartialEq)]
+pub struct CustomTheme {
+    pub window_background: String,
+    pub text_color: String,
+    pub active_tab_background: String,
+    pub active_tab_text: String,
+    pub inactive_tab_text: String,
+    pub hover_background: String,
+    pub hover_text: String,
+    pub secondary_text: String,
+    pub hover_secondary_text: String,
+    pub primary_font_size: String,
+    pub primary_font_family: String,
+    pub secondary_font_size: String,
+    pub secondary_font_family: String,
+    pub hotkey_background: String,
+    pub hotkey_text: String,
+    pub hover_hotkey_background: String,
+    pub hover_hotkey_text: String,
+}
+
+impl Default for CustomTheme {
+    fn default() -> Self {
+        Self {
+            window_background: "#292929".to_string(),
+            text_color: "#f0f0ea".to_string(),
+            active_tab_background: "#195ac2".to_string(),
+            active_tab_text: "#ffffff".to_string(),
+            inactive_tab_text: "#ffffff".to_string(),
+            hover_background: "#ffffff40".to_string(), // 25% white
+            hover_text: "#ffffff".to_string(),
+            secondary_text: "#bebebe".to_string(),
+            hover_secondary_text: "#ffffff".to_string(),
+            primary_font_size: "12.0".to_string(),
+            primary_font_family: "default".to_string(),
+            secondary_font_size: "11.0".to_string(),
+            secondary_font_family: "default".to_string(),
+            hotkey_background: "#292929".to_string(),
+            hotkey_text: "#808080".to_string(),
+            hover_hotkey_background: "#292929".to_string(),
+            hover_hotkey_text: "#ffffff".to_string(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]


### PR DESCRIPTION
https://github.com/Browsers-software/browsers/pull/384 extracted the focus fix from https://github.com/Browsers-software/browsers/pull/341 and this PR here rebases on top of new main branch.

> 
> - Replace hardcoded font size and color with `MainWindowTheme::ENV_PROFILE_LABEL_FONT` and `ENV_PROFILE_LABEL_COLOR`.
> - Aligns label appearance with the app's theming system for consistent UI.
> - Simplifies future theme customizations and reduces duplicated style values.
> 
> feat: Add customizable hotkey background and text colors, including hover states, to appearance settings and apply them to hotkey labels.
> 
> Remove redundant `SET_FOCUSED_INDEX` command submission from `else` block.
> 
> feat: Add UI options for custom font sizes and families, and implement browser focus state.
> 
> feat: add focus‑specific env customization and hover color settings
> 
> - Introduce `FocusWidget::with_env_on_focus` to apply a custom `Env` when the widget gains focus, affecting event, lifecycle, update, layout, and paint handling.
> - Extend `MainWindowTheme` with new keys `ENV_HOVER_TEXT_COLOR` and `ENV_HOVER_SECONDARY_TEXT_COLOR` and propagate them through theme initialization and environment setup.
> - Add corresponding fields (`hover_text_color`, `hover_secondary_text_color`) to the theme struct and default values in `CustomTheme`.
> - Update UI settings view to expose color inputs for hover text, secondary text, and hover secondary text, enabling user customization.
> - Adjust theme parsing to read the new color values from `CustomTheme` and apply them to the main window theme.
> 
> feat: add customizable hover background color support
> 
> - Add `hover_background` to `CustomTheme` with default RGBA value
> - Extend `MainWindowTheme` with `hover_background_color` and ENV key
> - Parse and apply the custom hover color when building the theme
> - Introduce a color input in the Appearance settings to let users edit the hover background
> - Update main window widget rendering to use the new env color for hover/selected states
> - Minor cleanup of imports and minor UI adjustments related to the new feature
> 
> feat: add custom appearance settings with theme customization
> 
> - Introduce an Appearance tab in the settings window allowing users to select theme mode and customize colors.
> - Replace the old ConfiguredTheme with a new ThemeMode enum that includes a Custom option.
> - Add a CustomTheme struct to store hex color values and provide default theme colors.
> - Extend UIVisualSettings and UIState to hold theme_mode and custom_theme data.
> - Update theme initialization to apply custom colors when ThemeMode::Custom is selected, including a color parser.
> - Modify settings UI to include radio buttons for theme selection and text boxes for custom color inputs, with automatic save handling.