### PR TITLE
allow theming hover/focus state

### DIFF
--- a/src/gui/focus_widget.rs
+++ b/src/gui/focus_widget.rs
@@ -18,6 +18,7 @@ pub struct FocusWidget<S: druid::Data + FocusData, W> {
     paint_fn_on_focus: fn(ctx: &mut PaintCtx, data: &S, env: &Env),
     lifecycle_fn: fn(ctx: &mut LifeCycleCtx, data: &S, env: &Env),
     hover_lost_fn: Option<fn(ctx: &mut LifeCycleCtx, data: &S, env: &Env)>,
+    env_fn_on_focus: Option<fn(&mut Env)>,
 }
 
 impl<S: druid::Data + FocusData, W> FocusWidget<S, W> {}
@@ -33,11 +34,19 @@ impl<S: druid::Data + FocusData, W> FocusWidget<S, W> {
             paint_fn_on_focus,
             lifecycle_fn,
             hover_lost_fn: None,
+            env_fn_on_focus: None,
         }
     }
 
     pub fn on_hover_lost(mut self, f: fn(ctx: &mut LifeCycleCtx, data: &S, env: &Env)) -> Self {
         self.hover_lost_fn = Some(f);
+        self
+    }
+
+    /// Overrides env values (e.g. swapping a color key to its hover variant) whenever
+    /// this widget has real focus, so descendants can just read the base keys as normal.
+    pub fn with_env_on_focus(mut self, f: fn(&mut Env)) -> Self {
+        self.env_fn_on_focus = Some(f);
         self
     }
 }
@@ -110,6 +119,13 @@ impl<S: druid::Data + FocusData, W: Widget<S>> Widget<S> for FocusWidget<S, W> {
             _ => {}
         }
 
+        if ctx.has_focus() {
+            if let Some(f) = self.env_fn_on_focus {
+                let mut env = env.clone();
+                f(&mut env);
+                return self.inner.event(ctx, event, data, &env);
+            }
+        }
         self.inner.event(ctx, event, data, env);
     }
 
@@ -158,6 +174,13 @@ impl<S: druid::Data + FocusData, W: Widget<S>> Widget<S> for FocusWidget<S, W> {
             }
             _ => {}
         }
+        if ctx.has_focus() {
+            if let Some(f) = self.env_fn_on_focus {
+                let mut env = env.clone();
+                f(&mut env);
+                return self.inner.lifecycle(ctx, event, data, &env);
+            }
+        }
         self.inner.lifecycle(ctx, event, data, env);
     }
 
@@ -165,16 +188,29 @@ impl<S: druid::Data + FocusData, W: Widget<S>> Widget<S> for FocusWidget<S, W> {
         /*if old_data.glow_hot != data.glow_hot {
             ctx.request_paint();
         }*/
+        if ctx.has_focus() {
+            if let Some(f) = self.env_fn_on_focus {
+                let mut env = env.clone();
+                f(&mut env);
+                return self.inner.update(ctx, old_data, data, &env);
+            }
+        }
         self.inner.update(ctx, old_data, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &S, env: &Env) -> Size {
+        // LayoutCtx has no has_focus(), but focus-driven colors don't affect layout size anyway
         self.inner.layout(ctx, bc, data, env)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &S, env: &Env) {
         if ctx.has_focus() {
             (self.paint_fn_on_focus)(ctx, data, env);
+            if let Some(f) = self.env_fn_on_focus {
+                let mut env = env.clone();
+                f(&mut env);
+                return self.inner.paint(ctx, data, &env);
+            }
         }
         self.inner.paint(ctx, data, env);
     }

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -116,8 +116,9 @@ impl MainWindow {
         const BOTTOM_ROW_HEIGHT: f64 = 18.0;
 
         let url_label = Label::dynamic(|data: &UIState, _| ellipsize(data.url.as_str(), 28))
-            .with_text_size(12.0)
-            .with_text_color(Color::from_hex_str("808080").unwrap())
+            .with_font(MainWindowTheme::ENV_URL_LABEL_FONT_FAMILY)
+            .with_text_size(MainWindowTheme::ENV_URL_LABEL_SIZE)
+            .with_text_color(MainWindowTheme::ENV_URL_LABEL_COLOR)
             .with_line_break_mode(LineBreaking::Clip)
             .with_text_alignment(TextAlignment::Start)
             .fix_height(BOTTOM_ROW_HEIGHT)
@@ -322,7 +323,7 @@ pub(crate) fn calculate_window_position(
     return Point::new(x, y);
 }
 
-fn create_browser_label() -> Label<((bool, UISettings), UIBrowser)> {
+fn create_browser_label() -> impl Widget<((bool, UISettings), UIBrowser)> {
     let browser_label = Label::dynamic(
         |((incognito_mode, _), item): &((bool, UISettings), UIBrowser), _env| {
             let mut name = item.browser_name.clone();
@@ -332,6 +333,7 @@ fn create_browser_label() -> Label<((bool, UISettings), UIBrowser)> {
             name
         },
     )
+    .with_font(MainWindowTheme::ENV_BROWSER_LABEL_FONT_FAMILY)
     .with_text_size(MainWindowTheme::ENV_BROWSER_LABEL_SIZE)
     .with_line_break_mode(LineBreaking::Clip)
     .with_text_alignment(TextAlignment::Start)
@@ -376,6 +378,7 @@ fn create_browser(
                 Label::dynamic(|(_, item): &((bool, UISettings), UIBrowser), _env: &_| {
                     item.profile_name.clone()
                 })
+                .with_font(MainWindowTheme::ENV_PROFILE_LABEL_FONT_FAMILY)
                 .with_text_size(MainWindowTheme::ENV_PROFILE_LABEL_SIZE)
                 .with_line_break_mode(LineBreaking::Clip)
                 .with_text_alignment(TextAlignment::Start)
@@ -459,10 +462,10 @@ fn create_browser(
 
     let container = FocusWidget::new(
         container,
-        |ctx, _: &((bool, UISettings), UIBrowser), _env| {
+        |ctx, _: &((bool, UISettings), UIBrowser), env| {
             let size = ctx.size();
             let rounded_rect = size.to_rounded_rect(5.0);
-            let color = Color::rgba(1.0, 1.0, 1.0, 0.25);
+            let color = env.get(MainWindowTheme::ENV_ITEM_BACKGROUND_COLOR_HOVER);
             ctx.fill(rounded_rect, &color);
         },
         |ctx, (_, data): &((bool, UISettings), UIBrowser), _env| {
@@ -483,6 +486,24 @@ fn create_browser(
                 .submit_command(SET_FOCUSED_INDEX, None, Target::Global)
                 .ok();
         }
+    })
+    .with_env_on_focus(|env| {
+        env.set(
+            MainWindowTheme::ENV_BROWSER_LABEL_COLOR,
+            env.get(MainWindowTheme::ENV_BROWSER_LABEL_COLOR_HOVER),
+        );
+        env.set(
+            MainWindowTheme::ENV_PROFILE_LABEL_COLOR,
+            env.get(MainWindowTheme::ENV_PROFILE_LABEL_COLOR_HOVER),
+        );
+        env.set(
+            MainWindowTheme::ENV_HOTKEY_TEXT_COLOR,
+            env.get(MainWindowTheme::ENV_HOTKEY_TEXT_COLOR_HOVER),
+        );
+        env.set(
+            MainWindowTheme::ENV_HOTKEY_BACKGROUND_COLOR,
+            env.get(MainWindowTheme::ENV_HOTKEY_BACKGROUND_COLOR_HOVER),
+        );
     });
 
     let container = Container::new(container);

--- a/src/gui/ui.rs
+++ b/src/gui/ui.rs
@@ -1,8 +1,8 @@
 use std::ops::Not;
 use std::path::PathBuf;
 use std::process::exit;
-use std::sync::mpsc::Sender;
 use std::sync::Arc;
+use std::sync::mpsc::Sender;
 
 use druid::commands::{CONFIGURE_WINDOW_SIZE_AND_POSITION, QUIT_APP, SHOW_WINDOW};
 use druid::{
@@ -14,9 +14,9 @@ use tracing::{debug, info, instrument};
 use url::Url;
 
 use crate::gui::main_window::{
-    calculate_window_position, recalculate_window_size, COPY_LINK_TO_CLIPBOARD, HIDE_ALL_PROFILES,
-    HIDE_PROFILE, MOVE_PROFILE, OPEN_LINK_IN_BROWSER, REFRESH, RESTORE_HIDDEN_PROFILE,
-    SET_BROWSERS_AS_DEFAULT_BROWSER, SET_FOCUSED_INDEX, SHOW_ABOUT_DIALOG, SHOW_SETTINGS_DIALOG,
+    COPY_LINK_TO_CLIPBOARD, HIDE_ALL_PROFILES, HIDE_PROFILE, MOVE_PROFILE, OPEN_LINK_IN_BROWSER,
+    REFRESH, RESTORE_HIDDEN_PROFILE, SET_BROWSERS_AS_DEFAULT_BROWSER, SET_FOCUSED_INDEX,
+    SHOW_ABOUT_DIALOG, SHOW_SETTINGS_DIALOG, calculate_window_position, recalculate_window_size,
 };
 use crate::gui::ui::SettingsTab::GENERAL;
 use crate::gui::{about_dialog, main_window, settings_window, ui_theme};

--- a/src/gui/ui_theme.rs
+++ b/src/gui/ui_theme.rs
@@ -1,7 +1,7 @@
 use crate::gui::ui::UIState;
 use crate::utils::ConfiguredTheme;
 use dark_light::Mode;
-use druid::{Color, Data, Env, Key};
+use druid::{Color, Data, Env, FontDescriptor, FontFamily, Key};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -76,13 +76,23 @@ fn get_theme(ui_theme: UITheme) -> Theme {
         main: MainWindowTheme {
             window_background_color: Color::rgba(0.15, 0.15, 0.15, 0.9),
             window_border_color: Color::rgba(0.5, 0.5, 0.5, 0.9),
+            item_background_color_hover: Color::rgba(1.0, 1.0, 1.0, 0.25),
+            browser_label_font_family: FontFamily::SYSTEM_UI,
             browser_label_size: 12.0,
             browser_label_color: Color::rgb8(255, 255, 255),
+            browser_label_color_hover: Color::rgb8(255, 255, 255),
+            profile_label_font_family: FontFamily::SYSTEM_UI,
             profile_label_size: 11.0,
             profile_label_color: Color::rgb8(190, 190, 190),
+            profile_label_color_hover: Color::rgb8(255, 255, 255),
+            url_label_font_family: FontFamily::SYSTEM_UI,
+            url_label_size: 12.0,
+            url_label_color: Color::rgb8(128, 128, 128),
             hotkey_background_color: Color::rgba(0.15, 0.15, 0.15, 1.0),
+            hotkey_background_color_hover: Color::rgba(0.15, 0.15, 0.15, 1.0),
             hotkey_border_color: Color::rgba(0.4, 0.4, 0.4, 0.9),
             hotkey_text_color: Color::rgb8(128, 128, 128),
+            hotkey_text_color_hover: Color::rgb8(255, 255, 255),
             options_button_text_color: Color::rgb8(128, 128, 128),
         },
         settings: SettingsWindowTheme {
@@ -131,13 +141,23 @@ fn get_theme(ui_theme: UITheme) -> Theme {
         main: MainWindowTheme {
             window_background_color: Color::rgba8(215, 215, 215, 230),
             window_border_color: Color::rgba(0.7, 0.7, 0.7, 0.9),
+            item_background_color_hover: Color::rgba(1.0, 1.0, 1.0, 0.25),
+            browser_label_font_family: FontFamily::SYSTEM_UI,
             browser_label_size: 12.0,
             browser_label_color: Color::rgb8(0, 0, 0),
+            browser_label_color_hover: Color::rgb8(0, 0, 0),
+            profile_label_font_family: FontFamily::SYSTEM_UI,
             profile_label_size: 11.0,
             profile_label_color: Color::rgb8(30, 30, 30),
+            profile_label_color_hover: Color::rgb8(0, 0, 0),
+            url_label_font_family: FontFamily::SYSTEM_UI,
+            url_label_size: 12.0,
+            url_label_color: Color::rgb8(128, 128, 128),
             hotkey_background_color: Color::rgb8(215, 215, 215),
+            hotkey_background_color_hover: Color::rgb8(215, 215, 215),
             hotkey_border_color: Color::rgba(0.4, 0.4, 0.4, 0.9),
             hotkey_text_color: Color::rgb8(128, 128, 128),
+            hotkey_text_color_hover: Color::rgb8(0, 0, 0),
             options_button_text_color: Color::rgb8(128, 128, 128),
         },
         settings: SettingsWindowTheme {
@@ -198,13 +218,23 @@ impl GeneralTheme {
 pub(crate) struct MainWindowTheme {
     window_background_color: Color,
     window_border_color: Color,
+    item_background_color_hover: Color,
+    browser_label_font_family: FontFamily,
     browser_label_size: f64,
     browser_label_color: Color,
+    browser_label_color_hover: Color,
+    profile_label_font_family: FontFamily,
     profile_label_size: f64,
     profile_label_color: Color,
+    profile_label_color_hover: Color,
+    url_label_font_family: FontFamily,
+    url_label_size: f64,
+    url_label_color: Color,
     hotkey_background_color: Color,
+    hotkey_background_color_hover: Color,
     hotkey_border_color: Color,
     hotkey_text_color: Color,
+    hotkey_text_color_hover: Color,
     options_button_text_color: Color,
 }
 
@@ -215,11 +245,23 @@ impl MainWindowTheme {
     pub const ENV_WINDOW_BORDER_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.window_border_color");
 
+    pub const ENV_ITEM_BACKGROUND_COLOR_HOVER: Key<Color> =
+        Key::new("software.browsers.theme.main.item_background_color_hover");
+
+    pub const ENV_BROWSER_LABEL_FONT_FAMILY: Key<FontDescriptor> =
+        Key::new("software.browsers.theme.main.browser_label_font_family");
+
     pub const ENV_BROWSER_LABEL_SIZE: Key<f64> =
         Key::new("software.browsers.theme.main.browser_label_size");
 
     pub const ENV_BROWSER_LABEL_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.browser_label_color");
+
+    pub const ENV_BROWSER_LABEL_COLOR_HOVER: Key<Color> =
+        Key::new("software.browsers.theme.main.browser_label_color_hover");
+
+    pub const ENV_PROFILE_LABEL_FONT_FAMILY: Key<FontDescriptor> =
+        Key::new("software.browsers.theme.main.profile_label_font_family");
 
     pub const ENV_PROFILE_LABEL_SIZE: Key<f64> =
         Key::new("software.browsers.theme.main.profile_label_size");
@@ -227,8 +269,23 @@ impl MainWindowTheme {
     pub const ENV_PROFILE_LABEL_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.profile_label_color");
 
+    pub const ENV_PROFILE_LABEL_COLOR_HOVER: Key<Color> =
+        Key::new("software.browsers.theme.main.profile_label_color_hover");
+
+    pub const ENV_URL_LABEL_FONT_FAMILY: Key<FontDescriptor> =
+        Key::new("software.browsers.theme.main.url_label_font_family");
+
+    pub const ENV_URL_LABEL_SIZE: Key<f64> =
+        Key::new("software.browsers.theme.main.url_label_size");
+
+    pub const ENV_URL_LABEL_COLOR: Key<Color> =
+        Key::new("software.browsers.theme.main.url_label_color");
+
     pub const ENV_HOTKEY_BACKGROUND_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.hotkey_background_color");
+
+    pub const ENV_HOTKEY_BACKGROUND_COLOR_HOVER: Key<Color> =
+        Key::new("software.browsers.theme.main.hotkey_background_color_hover");
 
     pub const ENV_HOTKEY_BORDER_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.hotkey_border_color");
@@ -236,19 +293,53 @@ impl MainWindowTheme {
     pub const ENV_HOTKEY_TEXT_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.hotkey_text_color");
 
+    pub const ENV_HOTKEY_TEXT_COLOR_HOVER: Key<Color> =
+        Key::new("software.browsers.theme.main.hotkey_text_color_hover");
+
     pub const ENV_OPTIONS_BUTTON_TEXT_COLOR: Key<Color> =
         Key::new("software.browsers.theme.main.options_button_text_color");
 
     fn set_env_to_theme(&self, env: &mut Env) {
         env.set(Self::ENV_WINDOW_BACKGROUND_COLOR, self.window_background_color);
         env.set(Self::ENV_WINDOW_BORDER_COLOR, self.window_border_color);
+        env.set(
+            Self::ENV_ITEM_BACKGROUND_COLOR_HOVER,
+            self.item_background_color_hover,
+        );
+        env.set(
+            Self::ENV_BROWSER_LABEL_FONT_FAMILY,
+            FontDescriptor::new(self.browser_label_font_family.clone()),
+        );
         env.set(Self::ENV_BROWSER_LABEL_SIZE, self.browser_label_size);
         env.set(Self::ENV_BROWSER_LABEL_COLOR, self.browser_label_color);
+        env.set(
+            Self::ENV_BROWSER_LABEL_COLOR_HOVER,
+            self.browser_label_color_hover,
+        );
+        env.set(
+            Self::ENV_PROFILE_LABEL_FONT_FAMILY,
+            FontDescriptor::new(self.profile_label_font_family.clone()),
+        );
         env.set(Self::ENV_PROFILE_LABEL_SIZE, self.profile_label_size);
         env.set(Self::ENV_PROFILE_LABEL_COLOR, self.profile_label_color);
+        env.set(
+            Self::ENV_PROFILE_LABEL_COLOR_HOVER,
+            self.profile_label_color_hover,
+        );
+        env.set(
+            Self::ENV_URL_LABEL_FONT_FAMILY,
+            FontDescriptor::new(self.url_label_font_family.clone()),
+        );
+        env.set(Self::ENV_URL_LABEL_SIZE, self.url_label_size);
+        env.set(Self::ENV_URL_LABEL_COLOR, self.url_label_color);
         env.set(Self::ENV_HOTKEY_BACKGROUND_COLOR, self.hotkey_background_color);
+        env.set(
+            Self::ENV_HOTKEY_BACKGROUND_COLOR_HOVER,
+            self.hotkey_background_color_hover,
+        );
         env.set(Self::ENV_HOTKEY_BORDER_COLOR, self.hotkey_border_color);
         env.set(Self::ENV_HOTKEY_TEXT_COLOR, self.hotkey_text_color);
+        env.set(Self::ENV_HOTKEY_TEXT_COLOR_HOVER, self.hotkey_text_color_hover);
         env.set(
             Self::ENV_OPTIONS_BUTTON_TEXT_COLOR,
             self.options_button_text_color,


### PR DESCRIPTION
Add more themed constants.

Adds `FocusedWidget.with_env_on_focus()` to allow updating env attributes during focusing.

Extracted from https://github.com/Browsers-software/browsers/pull/341 and modified